### PR TITLE
Release 0.14.0

### DIFF
--- a/Clients/ClientBase.ts
+++ b/Clients/ClientBase.ts
@@ -17,6 +17,67 @@
 
 import { TideError } from "../Errors/TideError";
 import { TideJsErrorCodes } from "../Errors/codes";
+import { RecentRequestsBuffer, RecentRequestEntry } from "./RecentRequestsBuffer";
+
+/**
+ * Derive a path-only endpoint from a full URL, falling back to the raw URL
+ * if URL parsing fails (e.g. relative URL with no base, or malformed input).
+ * Centralised here so every {@link RecentRequestsBuffer} entry is shaped the
+ * same way.
+ */
+function _endpointFromUrl(url: string): string {
+    try {
+        return new URL(url).pathname;
+    } catch {
+        return url;
+    }
+}
+
+/**
+ * Push a {@link RecentRequestEntry} for a request that has just resolved or
+ * rejected. Centralised so the per-method instrumentation in `_get`/`_post`/
+ * `_postJSON`/`_put` is small and consistent.
+ *
+ * `err` is examined defensively (we don't `instanceof TideError` because
+ * downstream bundlers can create cross-module instances): we check for the
+ * structural shape of TideError just like {@link TideError.isTideError}.
+ */
+function _pushRecent(
+    url: string,
+    method: string,
+    perfStart: number,
+    success: boolean,
+    response: Response | null,
+    err: unknown,
+): void {
+    const durationMs = performance.now() - perfStart;
+    let httpStatus: number | null = null;
+    let code: string | null = null;
+    if (success && response) {
+        httpStatus = response.status;
+        code = null;
+    } else if (TideError.isTideError(err)) {
+        httpStatus = (err as TideError).httpStatus ?? null;
+        code = (err as TideError).code;
+    } else {
+        httpStatus = null;
+        code = TideJsErrorCodes.NET_UNKNOWN;
+    }
+    const entry: RecentRequestEntry = {
+        timestamp: new Date().toISOString(),
+        url,
+        endpoint: _endpointFromUrl(url),
+        method,
+        httpStatus,
+        durationMs,
+        code,
+    };
+    try {
+        RecentRequestsBuffer.push(entry);
+    } catch {
+        /* never let buffer bookkeeping affect the actual request outcome */
+    }
+}
 
 /**
  * RFC 7807 Problem Details envelope, with Tide-specific extensions.
@@ -122,29 +183,36 @@ export default class ClientBase {
     async _get(endpoint: string, timeout: number = 20000, signal: AbortSignal = null): Promise<Response> {
         const controller = new AbortController();
         const id = setTimeout(() => controller.abort(), timeout);
+        const fullUrl = this.url + endpoint;
+        const perfStart = performance.now();
 
         let response;
         try {
-            response = await fetch(this.url + endpoint, {
+            response = await fetch(fullUrl, {
                 method: 'GET',
                 signal: signal ?? controller.signal
             });
             clearTimeout(id);
         } catch (e) {
             clearTimeout(id);
-            throw this._classifyFetchError(e, signal, "Clients/ClientBase.ts:_get", endpoint, "GET");
+            const tideErr = this._classifyFetchError(e, signal, "Clients/ClientBase.ts:_get", endpoint, "GET");
+            _pushRecent(fullUrl, "GET", perfStart, false, null, tideErr);
+            throw tideErr;
         }
         if (!response.ok) {
-            throw new TideError({
+            const tideErr = new TideError({
                 code: TideJsErrorCodes.NET_NON_OK_STATUS,
                 displayMessage: `Request to ${endpoint} returned HTTP ${response.status}`,
                 httpStatus: response.status,
                 source: "Clients/ClientBase.ts:_get",
-                url: this.url + endpoint,
+                url: fullUrl,
                 endpoint,
                 method: "GET",
             });
+            _pushRecent(fullUrl, "GET", perfStart, false, response, tideErr);
+            throw tideErr;
         }
+        _pushRecent(fullUrl, "GET", perfStart, true, response, null);
         return response;
     }
 
@@ -183,12 +251,14 @@ export default class ClientBase {
     async _post(endpoint: string, data: FormData, timeout: number = 20000): Promise<Response> {
         const controller = new AbortController();
         const id = setTimeout(() => controller.abort(), timeout);
+        const fullUrl = this.url + endpoint;
+        const perfStart = performance.now();
 
         if (this.token) data.append("token", this.token);
 
         let response;
         try {
-            response = await fetch(this.url + endpoint, {
+            response = await fetch(fullUrl, {
                 method: 'POST',
                 body: data,
                 signal: controller.signal
@@ -198,35 +268,84 @@ export default class ClientBase {
             clearTimeout(id);
             // `_post` does not accept a caller signal — abort can only come
             // from our own timeout controller.
-            throw this._classifyFetchError(e, null, "Clients/ClientBase.ts:_post", endpoint, "POST");
+            const tideErr = this._classifyFetchError(e, null, "Clients/ClientBase.ts:_post", endpoint, "POST");
+            _pushRecent(fullUrl, "POST", perfStart, false, null, tideErr);
+            throw tideErr;
         }
-        if (!response.ok) {
-            // Do NOT throw NET_NON_OK_STATUS here — for the voucher slice,
-            // ORK now returns 4xx/5xx with `application/problem+json`, and
-            // callers always pipe the response through `_handleError`, which
-            // parses Problem Details and constructs a richer TideError. Throw
-            // generically here would lose that information.
-            // Keep the response object; let the caller decide.
-        }
+        // Do NOT throw NET_NON_OK_STATUS here — for the voucher slice,
+        // ORK now returns 4xx/5xx with `application/problem+json`, and
+        // callers always pipe the response through `_handleError`, which
+        // parses Problem Details and constructs a richer TideError. Throw
+        // generically here would lose that information.
+        // From `_post`'s POV the request "succeeded" the moment the server
+        // produced any response (including 4xx/5xx) — we record the actual
+        // status; the downstream `_handleError` will not push another entry
+        // (it does not perform fetch, only parses the body), so this entry
+        // is the authoritative record of the request.
+        _pushRecent(fullUrl, "POST", perfStart, true, response, null);
         return response;
     }
 
     async _put(endpoint: string, data: FormData): Promise<Response> {
-        return fetch(this.url + endpoint, {
-            method: 'PUT',
-            body: data
-        });
+        const fullUrl = this.url + endpoint;
+        const perfStart = performance.now();
+        let response: Response;
+        try {
+            response = await fetch(fullUrl, {
+                method: 'PUT',
+                body: data
+            });
+        } catch (e) {
+            // No timeout/abort plumbing on `_put` historically; tag unknown
+            // failures as NET_FETCH_FAILED for the buffer.
+            const tideErr = TideError.isTideError(e)
+                ? (e as TideError)
+                : new TideError({
+                    code: TideJsErrorCodes.NET_FETCH_FAILED,
+                    displayMessage: "Network request failed",
+                    source: "Clients/ClientBase.ts:_put",
+                    url: fullUrl,
+                    endpoint,
+                    method: "PUT",
+                    cause: e,
+                });
+            _pushRecent(fullUrl, "PUT", perfStart, false, null, tideErr);
+            throw tideErr;
+        }
+        _pushRecent(fullUrl, "PUT", perfStart, true, response, null);
+        return response;
     }
 
     async _postJSON(endpoint: string, data: Object): Promise<Response> {
-        return fetch(this.url + endpoint, {
-            method: 'POST',
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(data)
-        });
+        const fullUrl = this.url + endpoint;
+        const perfStart = performance.now();
+        let response: Response;
+        try {
+            response = await fetch(fullUrl, {
+                method: 'POST',
+                headers: {
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(data)
+            });
+        } catch (e) {
+            const tideErr = TideError.isTideError(e)
+                ? (e as TideError)
+                : new TideError({
+                    code: TideJsErrorCodes.NET_FETCH_FAILED,
+                    displayMessage: "Network request failed",
+                    source: "Clients/ClientBase.ts:_postJSON",
+                    url: fullUrl,
+                    endpoint,
+                    method: "POST",
+                    cause: e,
+                });
+            _pushRecent(fullUrl, "POST", perfStart, false, null, tideErr);
+            throw tideErr;
+        }
+        _pushRecent(fullUrl, "POST", perfStart, true, response, null);
+        return response;
     }
 
     /**

--- a/Clients/ClientBase.ts
+++ b/Clients/ClientBase.ts
@@ -134,6 +134,95 @@ function _normalizeProblemDetails(problem: Record<string, unknown>): ProblemDeta
     };
 }
 
+// ---------------------------------------------------------------------------
+// ProblemDetails field validation (defense in depth).
+//
+// A ProblemDetails body is ATTACKER-CONTROLLED input (any ORK in the cohort
+// can emit one), so every field is validated/capped before it is allowed onto
+// a TideError. Rules (locked in the Phase 4 security review):
+//   - envelope fields must be strings or they are DROPPED;
+//   - `code` / `messageKey`: <= 256 chars, charset [A-Za-z0-9._:-] — DROPPED
+//     (not truncated, never thrown on) if either check fails;
+//   - `detail` / `title`: TRUNCATED to 2048 chars;
+//   - `traceId` / `source` / `type` / `instance`: TRUNCATED to 256 chars;
+//   - `status` must be a finite number or it is dropped;
+//   - `messageParams` must be a plain object (else dropped); at most 16 keys
+//     kept; keys must match ^[A-Za-z0-9_]{1,64}$ (and may not be a prototype-
+//     polluting name); values are coerced via String() and truncated to 256.
+// Dropped/truncated input NEVER causes a throw — the existing fallback paths
+// (e.g. PARSE_PROBLEM_JSON_INVALID when `code` is dropped) degrade gracefully.
+// ---------------------------------------------------------------------------
+
+const PD_CODE_LIKE = /^[A-Za-z0-9._:-]{1,256}$/;
+const PD_PARAM_KEY = /^[A-Za-z0-9_]{1,64}$/;
+const PD_TEXT_MAX = 2048;
+const PD_SHORT_MAX = 256;
+const PD_PARAMS_MAX_KEYS = 16;
+const PD_PARAM_VALUE_MAX = 256;
+
+/** String-or-drop, then truncate to `max`. */
+function _pdTruncated(v: unknown, max: number): string | undefined {
+    if (typeof v !== "string") return undefined;
+    return v.length > max ? v.slice(0, max) : v;
+}
+
+/** String-or-drop, then drop entirely unless it matches the code charset/length. */
+function _pdCodeLike(v: unknown): string | undefined {
+    if (typeof v !== "string") return undefined;
+    return PD_CODE_LIKE.test(v) ? v : undefined;
+}
+
+/**
+ * Sanitise `messageParams`: plain object only, capped key count, strict key
+ * charset, String()-coerced + truncated values. Keys that could reach the
+ * Object prototype chain (`__proto__`, `constructor`, `prototype`) are
+ * dropped outright even though `__proto__` matches the key regex — JSON.parse
+ * creates them as own properties, but a plain re-assignment here would hit
+ * the setter and pollute.
+ */
+function _pdSanitizeParams(v: unknown): Record<string, unknown> | null {
+    if (v === null || v === undefined) return null;
+    if (typeof v !== "object" || Array.isArray(v)) return null;
+    const proto = Object.getPrototypeOf(v);
+    if (proto !== Object.prototype && proto !== null) return null;
+
+    const out: Record<string, unknown> = {};
+    let kept = 0;
+    for (const key of Object.keys(v)) {
+        if (kept >= PD_PARAMS_MAX_KEYS) break;
+        if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+        if (!PD_PARAM_KEY.test(key)) continue;
+        let s: string;
+        try {
+            s = String((v as Record<string, unknown>)[key]);
+        } catch {
+            continue; // e.g. a Symbol value — drop the entry, never throw
+        }
+        out[key] = s.length > PD_PARAM_VALUE_MAX ? s.slice(0, PD_PARAM_VALUE_MAX) : s;
+        kept++;
+    }
+    return out;
+}
+
+/** Apply the validation rules above to a normalised ProblemDetails envelope. */
+function _sanitizeProblemDetails(problem: ProblemDetails): ProblemDetails {
+    const status = (typeof problem.status === "number" && Number.isFinite(problem.status))
+        ? problem.status
+        : undefined;
+    return {
+        type: _pdTruncated(problem.type, PD_SHORT_MAX),
+        title: _pdTruncated(problem.title, PD_TEXT_MAX),
+        status,
+        detail: _pdTruncated(problem.detail, PD_TEXT_MAX),
+        instance: _pdTruncated(problem.instance, PD_SHORT_MAX),
+        code: _pdCodeLike(problem.code),
+        traceId: _pdTruncated(problem.traceId, PD_SHORT_MAX),
+        source: _pdTruncated(problem.source, PD_SHORT_MAX),
+        messageKey: _pdCodeLike(problem.messageKey),
+        messageParams: _pdSanitizeParams(problem.messageParams),
+    };
+}
+
 export default class ClientBase {
     url: string;
     token: string;
@@ -457,8 +546,13 @@ export default class ClientBase {
             });
         }
 
+        // Normalise casing, then validate/cap every field (see the
+        // _sanitizeProblemDetails block above) — the body is attacker-
+        // controlled input. An invalid `code` is dropped by sanitisation,
+        // which routes the response into the PARSE_PROBLEM_JSON_INVALID
+        // fallback below rather than throwing.
         const problem = (parsed && typeof parsed === "object")
-            ? _normalizeProblemDetails(parsed as Record<string, unknown>)
+            ? _sanitizeProblemDetails(_normalizeProblemDetails(parsed as Record<string, unknown>))
             : null;
 
         if (!problem || typeof problem.code !== "string") {

--- a/Clients/ClientBase.ts
+++ b/Clients/ClientBase.ts
@@ -97,6 +97,43 @@ interface ProblemDetails {
     messageParams?: Record<string, unknown> | null;
 }
 
+/**
+ * Case-tolerant ProblemDetails field read.
+ *
+ * ORKs emit PascalCase field names on the wire (`Code`, `MessageKey`,
+ * `MessageParams`, ...) — that is the canonical form going forward — while
+ * older producers (and the RFC 7807 base spec) use lowercase. We accept both,
+ * preferring the lowercase spelling when both are present (matches the
+ * historical tide-js behaviour, which only ever read lowercase).
+ *
+ * NOTE: this tolerance applies to the ProblemDetails ENVELOPE field names
+ * only. `messageParams` dictionary KEYS pass through untouched (ork emits
+ * them lowercase, e.g. `minutes`, `expirySeconds`).
+ */
+function _pdField<T>(problem: Record<string, unknown>, lower: string, pascal: string): T | undefined {
+    const v = problem[lower] !== undefined ? problem[lower] : problem[pascal];
+    return v as T | undefined;
+}
+
+/**
+ * Normalise a parsed problem+json body (either casing) into the lowercase
+ * {@link ProblemDetails} shape used internally.
+ */
+function _normalizeProblemDetails(problem: Record<string, unknown>): ProblemDetails {
+    return {
+        type: _pdField<string>(problem, "type", "Type"),
+        title: _pdField<string>(problem, "title", "Title"),
+        status: _pdField<number>(problem, "status", "Status"),
+        detail: _pdField<string>(problem, "detail", "Detail"),
+        instance: _pdField<string>(problem, "instance", "Instance"),
+        code: _pdField<string>(problem, "code", "Code"),
+        traceId: _pdField<string>(problem, "traceId", "TraceId"),
+        source: _pdField<string>(problem, "source", "Source"),
+        messageKey: _pdField<string | null>(problem, "messageKey", "MessageKey"),
+        messageParams: _pdField<Record<string, unknown> | null>(problem, "messageParams", "MessageParams"),
+    };
+}
+
 export default class ClientBase {
     url: string;
     token: string;
@@ -200,6 +237,15 @@ export default class ClientBase {
             throw tideErr;
         }
         if (!response.ok) {
+            // Structured ORK errors (e.g. 409 USERNAME_RESERVED on
+            // GetReservers) arrive as `application/problem+json` — parse and
+            // pass them through instead of collapsing to NET_NON_OK_STATUS.
+            const problemError = await this._problemDetailsToError(
+                response, "Clients/ClientBase.ts:_get", fullUrl, endpoint, "GET");
+            if (problemError) {
+                _pushRecent(fullUrl, "GET", perfStart, false, response, problemError);
+                throw problemError;
+            }
             const tideErr = new TideError({
                 code: TideJsErrorCodes.NET_NON_OK_STATUS,
                 displayMessage: `Request to ${endpoint} returned HTTP ${response.status}`,
@@ -235,6 +281,9 @@ export default class ClientBase {
             throw this._classifyFetchError(e, signal, "Clients/ClientBase.ts:_getSilent", endpoint, "GET");
         }
         if (!response.ok) {
+            const problemError = await this._problemDetailsToError(
+                response, "Clients/ClientBase.ts:_getSilent", this.url + endpoint, endpoint, "GET");
+            if (problemError) throw problemError;
             throw new TideError({
                 code: TideJsErrorCodes.NET_NON_OK_STATUS,
                 displayMessage: `Request to ${endpoint} returned HTTP ${response.status}`,
@@ -371,6 +420,82 @@ export default class ClientBase {
     }
 
     /**
+     * If `response` carries an `application/problem+json` body, read + parse
+     * it (case-tolerantly — see {@link _normalizeProblemDetails}) and return
+     * the structured pass-through {@link TideError} to throw. Returns `null`
+     * when the content-type is not problem+json (body is NOT consumed in
+     * that case, so callers may still read it).
+     *
+     * A malformed body / missing `code` yields a `PARSE_PROBLEM_JSON_INVALID`
+     * TideError rather than `null`, mirroring the historical `_handleError`
+     * behaviour.
+     */
+    private async _problemDetailsToError(
+        response: Response,
+        source: string,
+        url: string | undefined,
+        endpoint: string | undefined,
+        method?: string,
+    ): Promise<TideError | null> {
+        const contentType = response.headers.get("content-type") ?? "";
+        if (!contentType.toLowerCase().includes("application/problem+json")) return null;
+
+        const raw = await response.text();
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(raw);
+        } catch (parseErr) {
+            return new TideError({
+                code: TideJsErrorCodes.PARSE_PROBLEM_JSON_INVALID,
+                displayMessage: "Server returned application/problem+json but the body did not parse",
+                httpStatus: response.status,
+                source,
+                url,
+                endpoint,
+                method,
+                cause: parseErr,
+            });
+        }
+
+        const problem = (parsed && typeof parsed === "object")
+            ? _normalizeProblemDetails(parsed as Record<string, unknown>)
+            : null;
+
+        if (!problem || typeof problem.code !== "string") {
+            return new TideError({
+                code: TideJsErrorCodes.PARSE_PROBLEM_JSON_INVALID,
+                displayMessage: "Server returned application/problem+json without a `code` field",
+                httpStatus: response.status,
+                source,
+                url,
+                endpoint,
+                method,
+                problemType: problem?.type,
+                cause: raw,
+            });
+        }
+
+        // Pass-through. The upstream `code` (e.g. `TIDE-ORK-SIG-VERIFY_FAILED`)
+        // is preserved verbatim — keycloak-IGA's `getTideErrorInfo` expects
+        // to see the originating code, not a tide-js wrapper code. Likewise
+        // `messageKey` is copied through UNMODIFIED (no prefix assumptions —
+        // the Enclave performs its own lookup remap).
+        return new TideError({
+            code: problem.code,
+            displayMessage: problem.detail ?? problem.title ?? "Upstream error",
+            messageKey: problem.messageKey ?? null,
+            messageParams: problem.messageParams ?? null,
+            traceId: problem.traceId,
+            source: problem.source,
+            httpStatus: problem.status ?? response.status,
+            problemType: problem.type,
+            url,
+            endpoint,
+            method,
+        });
+    }
+
+    /**
      * Convert a server response into either:
      *  - a success body (`text/plain`, voucher path, 2xx)
      *  - a thrown {@link TideError} (any error path)
@@ -390,7 +515,6 @@ export default class ClientBase {
      * @param _throwError Deprecated, retained for ABI compatibility. Errors are always thrown.
      */
     async _handleError(response: Response, functionName: string = "", _throwError: boolean = false): Promise<string> {
-        const contentType = response.headers.get("content-type") ?? "";
         const source = `Clients/ClientBase.ts:_handleError(${functionName})`;
         // `response.url` is the final URL (post-redirect). We use it as a
         // best-effort source for the debug fields; `_handleError` doesn't
@@ -403,52 +527,8 @@ export default class ClientBase {
         }
 
         // ---- (1) Problem Details (RFC 7807 + Tide extensions) -------------
-        if (contentType.toLowerCase().includes("application/problem+json")) {
-            const raw = await response.text();
-            let problem: ProblemDetails;
-            try {
-                problem = JSON.parse(raw) as ProblemDetails;
-            } catch (parseErr) {
-                throw new TideError({
-                    code: TideJsErrorCodes.PARSE_PROBLEM_JSON_INVALID,
-                    displayMessage: "Server returned application/problem+json but the body did not parse",
-                    httpStatus: response.status,
-                    source,
-                    url,
-                    endpoint,
-                    cause: parseErr,
-                });
-            }
-
-            if (!problem || typeof problem !== "object" || typeof problem.code !== "string") {
-                throw new TideError({
-                    code: TideJsErrorCodes.PARSE_PROBLEM_JSON_INVALID,
-                    displayMessage: "Server returned application/problem+json without a `code` field",
-                    httpStatus: response.status,
-                    source,
-                    url,
-                    endpoint,
-                    problemType: problem?.type,
-                    cause: raw,
-                });
-            }
-
-            // Pass-through. The upstream `code` (e.g. `TIDE-ORK-SIG-VERIFY_FAILED`)
-            // is preserved verbatim — keycloak-IGA's `getTideErrorInfo` expects
-            // to see the originating code, not a tide-js wrapper code.
-            throw new TideError({
-                code: problem.code,
-                displayMessage: problem.detail ?? problem.title ?? "Upstream error",
-                messageKey: problem.messageKey ?? null,
-                messageParams: problem.messageParams ?? null,
-                traceId: problem.traceId,
-                source: problem.source,
-                httpStatus: problem.status ?? response.status,
-                problemType: problem.type,
-                url,
-                endpoint,
-            });
-        }
+        const problemError = await this._problemDetailsToError(response, source, url, endpoint);
+        if (problemError) throw problemError;
 
         const responseData = await response.text();
 

--- a/Clients/RecentRequestsBuffer.ts
+++ b/Clients/RecentRequestsBuffer.ts
@@ -1,0 +1,92 @@
+//
+// Tide Protocol - Infrastructure for a TRUE Zero-Trust paradigm
+// Copyright (C) 2022 Tide Foundation Ltd
+//
+// This program is free software and is subject to the terms of
+// the Tide Community Open Code License as published by the
+// Tide Foundation Limited. You may modify it and redistribute
+// it in accordance with and subject to the terms of that License.
+// This program is distributed WITHOUT WARRANTY of any kind,
+// including without any implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+// See the Tide Community Open Code License for more details.
+// You should have received a copy of the Tide Community Open
+// Code License along with this program.
+// If not, see https://tide.org/licenses_tcoc2-0-0-en
+//
+
+/**
+ * A single recent HTTP request observed by the tide-js {@link ClientBase}
+ * pipeline. The raw `url` is captured here verbatim; URL sanitization
+ * (e.g. stripping uid query params) is the responsibility of the
+ * report-building code that drains the buffer, not this module.
+ */
+export interface RecentRequestEntry {
+    /** ISO-8601 timestamp of when the request completed (success) or threw (failure). */
+    timestamp: string;
+    /** Raw URL — sanitization happens at report-build time, not here. */
+    url: string;
+    /** Path-only portion of the URL (best-effort; falls back to raw `url` if `new URL(...)` fails). */
+    endpoint: string;
+    /** HTTP method, e.g. "GET" / "POST" / "PUT". */
+    method: string;
+    /** HTTP status code on response, or `null` on pre-response failure (DNS, CORS, abort, timeout, ...). */
+    httpStatus: number | null;
+    /** Duration in milliseconds, measured via `performance.now()`. */
+    durationMs: number;
+    /** TideError code if the request failed and threw; `null` on success. */
+    code: string | null;
+}
+
+/**
+ * FIFO bounded ring buffer of the most recent HTTP requests issued via
+ * {@link ClientBase}. In-memory only — never persisted to localStorage,
+ * sessionStorage, or IndexedDB.
+ *
+ * Singleton state lives at module scope so any code that imports the class
+ * sees the same buffer, regardless of how many client instances exist.
+ *
+ * Default capacity is 20; callers can override via {@link setCapacity}.
+ *
+ * The buffer is drained at report-build time (e.g. when constructing a
+ * tide-js error report) — sanitization of `url` happens there.
+ */
+export class RecentRequestsBuffer {
+    private static _capacity = 20;
+    private static _entries: RecentRequestEntry[] = [];
+
+    /** Append an entry; oldest entries are evicted FIFO when capacity is exceeded. */
+    static push(entry: RecentRequestEntry): void {
+        // Defensive copy so callers can't mutate buffered entries after the fact.
+        RecentRequestsBuffer._entries.push({ ...entry });
+        const overflow = RecentRequestsBuffer._entries.length - RecentRequestsBuffer._capacity;
+        if (overflow > 0) {
+            RecentRequestsBuffer._entries.splice(0, overflow);
+        }
+    }
+
+    /** Returns the up-to-last-N entries in insertion order (oldest first). */
+    static snapshot(): RecentRequestEntry[] {
+        // Return a defensive shallow-copy + per-entry copy so callers can't
+        // mutate the live buffer.
+        return RecentRequestsBuffer._entries.map(e => ({ ...e }));
+    }
+
+    /** Empty the buffer. */
+    static clear(): void {
+        RecentRequestsBuffer._entries = [];
+    }
+
+    /**
+     * Override the bounded capacity. If `n` is less than the current size,
+     * the oldest entries are evicted FIFO to fit.
+     */
+    static setCapacity(n: number): void {
+        if (!Number.isFinite(n) || n < 0) return;
+        RecentRequestsBuffer._capacity = Math.floor(n);
+        const overflow = RecentRequestsBuffer._entries.length - RecentRequestsBuffer._capacity;
+        if (overflow > 0) {
+            RecentRequestsBuffer._entries.splice(0, overflow);
+        }
+    }
+}

--- a/Clients/index.ts
+++ b/Clients/index.ts
@@ -19,3 +19,5 @@ export { default as ClientBase } from './ClientBase';
 export { default as NetworkClient } from './NetworkClient';
 export { default as NodeClient } from './NodeClient';
 export { default as VoucherClient } from './VoucherClient';
+export { RecentRequestsBuffer } from './RecentRequestsBuffer';
+export type { RecentRequestEntry } from './RecentRequestsBuffer';

--- a/Cryptide/Components/BaseComponent.ts
+++ b/Cryptide/Components/BaseComponent.ts
@@ -19,68 +19,70 @@ import { base64ToBytes, Bytes2Hex, bytesToBase64, ConcatUint8Arrays, getBytesFro
 import { Registery } from "./ComponentRegistry";
 import BaseScheme from "./Schemes/BaseScheme";
 import { SchemeType } from "./Schemes/SchemeRegistry";
+import { TideError } from "../../Errors/TideError";
+import { TideJsErrorCodes } from "../../Errors/codes";
 
 export class BaseComponent{
     constructor(){}
-    static Name: any = () => { throw Error("Name not implemented"); }
-    static Version: any = () => { throw Error("Version not implemented"); }
+    static Name: any = () => { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Name not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:25" }); }
+    static Version: any = () => { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Version not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:26" }); }
 
     Add(component){
         if(component.Scheme == this.Scheme){
             let res = this.AddComponent(component) as any;
             if(res instanceof BaseComponent && res.Scheme == this.Scheme) return res;
         }
-        throw Error("Mismatch between components");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_COMPONENT_MISMATCH, displayMessage: "Mismatch between components", source: "tide-js/Cryptide/Components/BaseComponent.ts:33" });
     }
     Multiply(component){
         if(component.Scheme == this.Scheme){
             let res = this.MultiplyComponent(component) as any;
             if(res instanceof BaseComponent && res.Scheme == this.Scheme) return res;
         }
-        throw Error("Mismatch between components");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_COMPONENT_MISMATCH, displayMessage: "Mismatch between components", source: "tide-js/Cryptide/Components/BaseComponent.ts:40" });
     }
     Minus(component){
         if(component.Scheme == this.Scheme){
             let res = this.MinusComponent(component) as any;
             if(res instanceof BaseComponent && res.Scheme == this.Scheme) return res;
         }
-        throw Error("Mismatch between components");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_COMPONENT_MISMATCH, displayMessage: "Mismatch between components", source: "tide-js/Cryptide/Components/BaseComponent.ts:47" });
     }
     Equals(component){
         if(component.Scheme == this.Scheme){
             let res = this.EqualsComponent(component);
             if(typeof res == "boolean") return res;
         }
-        throw Error("Mismatch between components");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_COMPONENT_MISMATCH, displayMessage: "Mismatch between components", source: "tide-js/Cryptide/Components/BaseComponent.ts:54" });
     }
     Mod(){
         let res = this.ModComponent() as any;
         if(res instanceof BaseComponent && res.Scheme == this.Scheme) return res;
-        throw Error("Mismatch between components");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_COMPONENT_MISMATCH, displayMessage: "Mismatch between components", source: "tide-js/Cryptide/Components/BaseComponent.ts:59" });
     }
     ModInv(){
         let res = this.ModInvComponent() as any;
         if(res instanceof BaseComponent && res.Scheme == this.Scheme) return res;
-        throw Error("Mismatch between components");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_COMPONENT_MISMATCH, displayMessage: "Mismatch between components", source: "tide-js/Cryptide/Components/BaseComponent.ts:64" });
     }
 
-    AddComponent(component){ throw Error("Add not implemented"); }
-    MultiplyComponent(component){ throw Error("Multiply not implemented"); }
-    MinusComponent(component){ throw Error("Minus not implemented"); }
-    EqualsComponent(component){ throw Error("Equals not implemented"); }
-    ModComponent(){ throw Error("Mod not implemented"); }
-    ModInvComponent(){ throw Error("Mod inv not implemented"); }
-    SerializeComponent(): Uint8Array { throw Error("Serialize not implemented"); }
+    AddComponent(component){ throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Add not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:67" }); }
+    MultiplyComponent(component){ throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Multiply not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:68" }); }
+    MinusComponent(component){ throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Minus not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:69" }); }
+    EqualsComponent(component){ throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Equals not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:70" }); }
+    ModComponent(){ throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Mod not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:71" }); }
+    ModInvComponent(){ throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Mod inv not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:72" }); }
+    SerializeComponent(): Uint8Array { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Serialize not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:73" }); }
     /**@returns {BaseScheme} */
-    get Scheme(): any { throw Error("Not implemented"); }
+    get Scheme(): any { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:75" }); }
     /**@returns {string} */
-    get ComponentType(): string { throw Error("Not implemented"); }
+    get ComponentType(): string { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:77" }); }
 
     Serialize(): SerializedComponent {
         let raw = this.SerializeComponent();
         let schemeInt = SchemeType.indexOf(this.Scheme as any);
         let componentTypeInt = ComponentKeyType.indexOf(this.ComponentType as any);
-        if(schemeInt == -1 || componentTypeInt == -1) throw Error("Could not find scheme or component type in registries");
+        if(schemeInt == -1 || componentTypeInt == -1) throw new TideError({ code: TideJsErrorCodes.CRYPTO_UNKNOWN_COMPONENT_TYPE, displayMessage: "Could not find scheme or component type in registries", source: "tide-js/Cryptide/Components/BaseComponent.ts:83" });
 
         let schemeBytes = getBytesFromInt16(schemeInt);
         let header = ConcatUint8Arrays([new Uint8Array([componentTypeInt << 4]), schemeBytes]); // shift to the left (for when we have version, but all versions are 0 for now)
@@ -98,7 +100,7 @@ export class BaseComponent{
                     b = base64ToBytes(serialized);
                 }
             }catch{
-                throw Error("Unable to deserialize component");
+                throw new TideError({ code: TideJsErrorCodes.CRYPTO_DESERIALIZE_FAILED, displayMessage: "Unable to deserialize component", source: "tide-js/Cryptide/Components/BaseComponent.ts:101" });
             }
         }else b = serialized;
         let scheme = SchemeType[toInt16(b.slice(1, 3), 0)];
@@ -112,23 +114,23 @@ export class BaseComponent{
 
 export class BaseSeedComponent extends BaseComponent{
     get ComponentType() { return Seed; }
-    static New() { throw Error("Not implemented"); }
-    GetPublic(): BasePublicComponent { throw Error("Not implemented"); }
-    GetPrivate(): BasePrivateComponent { throw Error("Not implemented"); }
-    get rawBytes(): Uint8Array { throw Error("Not implemented"); }
+    static New() { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:115" }); }
+    GetPublic(): BasePublicComponent { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:116" }); }
+    GetPrivate(): BasePrivateComponent { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:117" }); }
+    get rawBytes(): Uint8Array { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:118" }); }
 }
 
 export class BasePrivateComponent extends BaseComponent{
     get ComponentType() { return Private; }
-    static New() { throw Error("Not implemented"); }
-    GetPublic(): BasePublicComponent { throw Error("Not implemented"); }
-    get priv(): bigint { throw Error("Not implemented"); }
-    get rawBytes(): Uint8Array { throw Error("Not implemented"); }
+    static New() { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:123" }); }
+    GetPublic(): BasePublicComponent { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:124" }); }
+    get priv(): bigint { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:125" }); }
+    get rawBytes(): Uint8Array { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:126" }); }
 }
 
 export class BasePublicComponent extends BaseComponent{
     get ComponentType() { return Public; }
-    get public(): any { throw Error("Not implemented"); }
+    get public(): any { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented", source: "tide-js/Cryptide/Components/BaseComponent.ts:131" }); }
 }
 
 export class SerializedComponent{
@@ -154,11 +156,11 @@ export class SerializedComponent{
             case Symmetric:
                 return bytesToBase64(this.Bytes);
             case QuantumPrivate:
-                throw Error("Not implemented yet");
+                throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented yet", source: "tide-js/Cryptide/Components/BaseComponent.ts:157" });
             case QuantumPublic:
-                throw Error("Not implemented yet");
+                throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Not implemented yet", source: "tide-js/Cryptide/Components/BaseComponent.ts:159" });
             default:
-                throw Error("Unknown component type");
+                throw new TideError({ code: TideJsErrorCodes.CRYPTO_UNKNOWN_COMPONENT_TYPE, displayMessage: "Unknown component type", source: "tide-js/Cryptide/Components/BaseComponent.ts:161" });
         }
     }
 }

--- a/Cryptide/Components/Schemes/BaseScheme.ts
+++ b/Cryptide/Components/Schemes/BaseScheme.ts
@@ -1,23 +1,26 @@
-// 
+//
 // Tide Protocol - Infrastructure for a TRUE Zero-Trust paradigm
 // Copyright (C) 2022 Tide Foundation Ltd
-// 
-// This program is free software and is subject to the terms of 
-// the Tide Community Open Code License as published by the 
-// Tide Foundation Limited. You may modify it and redistribute 
+//
+// This program is free software and is subject to the terms of
+// the Tide Community Open Code License as published by the
+// Tide Foundation Limited. You may modify it and redistribute
 // it in accordance with and subject to the terms of that License.
-// This program is distributed WITHOUT WARRANTY of any kind, 
-// including without any implied warranty of MERCHANTABILITY or 
+// This program is distributed WITHOUT WARRANTY of any kind,
+// including without any implied warranty of MERCHANTABILITY or
 // FITNESS FOR A PARTICULAR PURPOSE.
 // See the Tide Community Open Code License for more details.
-// You should have received a copy of the Tide Community Open 
+// You should have received a copy of the Tide Community Open
 // Code License along with this program.
 // If not, see https://tide.org/licenses_tcoc2-0-0-en
 //
 
+import { TideError } from "../../../Errors/TideError";
+import { TideJsErrorCodes } from "../../../Errors/codes";
+
 export default class BaseScheme{
-    static get Name(): string { throw Error("Name not implemented"); }
-    static GetVerifyingFunction = (): any => { throw Error("Verifying function not implemented"); }
-    static GetSigningFunction = (): any => { throw Error("Signing function not implemented"); }
-    static GetEncryptingFunction = (): any => { throw Error("Encrypting function not implemented"); }
+    static get Name(): string { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Name not implemented", source: "tide-js/Cryptide/Components/Schemes/BaseScheme.ts:22" }); }
+    static GetVerifyingFunction = (): any => { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Verifying function not implemented", source: "tide-js/Cryptide/Components/Schemes/BaseScheme.ts:23" }); }
+    static GetSigningFunction = (): any => { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Signing function not implemented", source: "tide-js/Cryptide/Components/Schemes/BaseScheme.ts:24" }); }
+    static GetEncryptingFunction = (): any => { throw new TideError({ code: TideJsErrorCodes.CRYPTO_NOT_IMPLEMENTED, displayMessage: "Encrypting function not implemented", source: "tide-js/Cryptide/Components/Schemes/BaseScheme.ts:25" }); }
 }

--- a/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts
+++ b/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts
@@ -20,6 +20,8 @@ import { mod,} from "../../../Math";
 import { BigIntFromByteArray, BigIntToByteArray} from "../../../Serialization";
 import { Public, Private, Seed, BaseSeedComponent, BasePrivateComponent, BasePublicComponent } from "../../BaseComponent";
 import Ed25519Scheme from "./Ed25519Scheme";
+import { TideError } from "../../../../Errors/TideError";
+import { TideJsErrorCodes } from "../../../../Errors/codes";
 
 export class Ed25519PublicComponent extends BasePublicComponent{
     static Name = "Ed25519PublicComponent";
@@ -37,17 +39,17 @@ export class Ed25519PublicComponent extends BasePublicComponent{
             this.p = rawData;
         }else if(rawData instanceof Uint8Array){
             this.pb = rawData;
-        }else{ throw Error("unexpected type;") }
+        }else{ throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_TYPE, displayMessage: "Ed25519PublicComponent: unexpected type (expected Point or Uint8Array)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts:42" }); }
     }
     get public() {
         if(!this.p && this.pb) this.p = Point.fromBytes(this.pb);
-        else if(!this.p && !this.pb) throw Error("empty object");
+        else if(!this.p && !this.pb) throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: "Ed25519PublicComponent.public: empty object (neither point nor bytes set)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts:46" });
         return this.p;
     }
-    
+
     get rawBytes() {
         if(!this.pb && this.p) this.pb = this.p.toRawBytes();
-        else if(!this.pb && !this.p) throw Error("empty object");
+        else if(!this.pb && !this.p) throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: "Ed25519PublicComponent.rawBytes: empty object (neither point nor bytes set)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts:52" });
         return this.pb;
     }
 
@@ -55,25 +57,25 @@ export class Ed25519PublicComponent extends BasePublicComponent{
         if(component instanceof Ed25519PublicComponent){
             return new Ed25519PublicComponent(this.public.add(component.public));
         }
-        throw Error("Mismatch with components");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_COMPONENT_MISMATCH, displayMessage: "Ed25519PublicComponent.Add: mismatch with components (expected Ed25519PublicComponent)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts:60" });
     }
     MultiplyComponent(component){
         if(component instanceof Ed25519PrivateComponent){
             return new Ed25519PublicComponent(this.public.mul(component.priv));
         }
-        throw Error("Mismatch with components");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_COMPONENT_MISMATCH, displayMessage: "Ed25519PublicComponent.Multiply: mismatch with components (expected Ed25519PrivateComponent)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts:66" });
     }
     MinusComponent(component){
         if(component instanceof Ed25519PublicComponent){
             return new Ed25519PublicComponent(this.public.add(component.public.negate()));
         }
-        throw Error("Mismatch with components");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_COMPONENT_MISMATCH, displayMessage: "Ed25519PublicComponent.Minus: mismatch with components (expected Ed25519PublicComponent)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts:72" });
     }
     EqualsComponent(component){
         if(component instanceof Ed25519PublicComponent){
             return this.public.equals(component.public);
         }
-        throw Error("Mismatch with components");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_COMPONENT_MISMATCH, displayMessage: "Ed25519PublicComponent.Equals: mismatch with components (expected Ed25519PublicComponent)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts:78" });
     }
     SerializeComponent(){
         return this.rawBytes.slice();
@@ -93,13 +95,13 @@ export class Ed25519PrivateComponent extends BasePrivateComponent{
 
     get priv() {
         if(!this.p && this.rB) this.p = BigIntFromByteArray(this.rB);
-        else if (!this.p && !this.rB) throw Error("Empty object");
+        else if (!this.p && !this.rB) throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: "Ed25519PrivateComponent.priv: empty object (neither bigint nor bytes set)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts:98" });
         return this.p;
     }
 
     get rawBytes() {
         if(!this.rB && this.p) this.rB = BigIntToByteArray(this.p);
-        else if(!this.rB && !this.p) throw Error("Empty object");
+        else if(!this.rB && !this.p) throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: "Ed25519PrivateComponent.rawBytes: empty object (neither bigint nor bytes set)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts:104" });
         return this.rB;
     }
 
@@ -109,7 +111,7 @@ export class Ed25519PrivateComponent extends BasePrivateComponent{
             this.p = rawData;
         }else if(rawData instanceof Uint8Array){
             this.rB = rawData;
-        }else{ throw Error("unexpected type;") }
+        }else{ throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_TYPE, displayMessage: "Ed25519PrivateComponent: unexpected type (expected bigint or Uint8Array)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts:114" }); }
     }
     SerializeComponent(){
         return this.rawBytes.slice();
@@ -139,7 +141,7 @@ export class Ed25519SeedComponent extends BaseSeedComponent{
         super();
         if(rawData instanceof Uint8Array) this.rB = rawData.slice();
         else if(!rawData) this.rB = Ed25519SeedComponent.GenerateSeed(); // if nothing provided - self instanciate
-        else throw Error("Expecting Uint8Array or nothing for constructor");
+        else throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_TYPE, displayMessage: "Ed25519SeedComponent: expected Uint8Array or no argument", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Components.ts:144" });
     }
 
     SerializeComponent(){

--- a/Cryptide/Components/Schemes/Ed25519/Ed25519Scheme.ts
+++ b/Cryptide/Components/Schemes/Ed25519/Ed25519Scheme.ts
@@ -19,6 +19,8 @@ import { signNonDeterministicAsync, verifyAsync } from "../../../Ed25519";
 import ElGamal from "../../../Encryption/ElGamal";
 import BaseScheme from "../BaseScheme";
 import { Ed25519PrivateComponent, Ed25519PublicComponent, Ed25519SeedComponent } from "./Ed25519Components";
+import { TideError } from "../../../../Errors/TideError";
+import { TideJsErrorCodes } from "../../../../Errors/codes";
 
 export default class Ed25519Scheme extends BaseScheme{
     static get Name() { return "Ed25519Scheme"; }
@@ -31,7 +33,7 @@ export default class Ed25519Scheme extends BaseScheme{
             if(msg instanceof Uint8Array && component instanceof Ed25519PrivateComponent){
                 return signNonDeterministicAsync(msg, component.priv);
             }
-            throw Error("Mismatch of expected types (Uint8Array, Ed25519PrivateComponent)");
+            throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_TYPE, displayMessage: "Ed25519Scheme.sign: mismatch of expected types (Uint8Array, Ed25519PrivateComponent)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Scheme.ts:36" });
         }
         return signingFunc;
     }
@@ -39,9 +41,9 @@ export default class Ed25519Scheme extends BaseScheme{
         const verifyingFunc = async (msg, signature, component) => {
             if(msg instanceof Uint8Array && signature instanceof Uint8Array && component instanceof Ed25519PublicComponent){
                 const valid = await verifyAsync(signature, msg, component.rawBytes);
-                if(!valid) throw Error("Signature validation failed");
+                if(!valid) throw new TideError({ code: TideJsErrorCodes.SIG_VERIFY_FAILED, displayMessage: "Ed25519 signature validation failed", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Scheme.ts:44" });
             }
-            else throw Error("Mismatch of expected types (Uint8Array, Uint8Array, Ed25519PublicComponent)");
+            else throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_TYPE, displayMessage: "Ed25519Scheme.verify: mismatch of expected types (Uint8Array, Uint8Array, Ed25519PublicComponent)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Scheme.ts:46" });
         }
         return verifyingFunc;
     }
@@ -50,7 +52,7 @@ export default class Ed25519Scheme extends BaseScheme{
             if(msg instanceof Uint8Array && component instanceof Ed25519PublicComponent){
                 return await ElGamal.encryptDataRaw(msg, component.public);
             }
-            else throw Error("Mismatch between expected types (Uint8Array, Ed25519PublicComponent)");
+            else throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_TYPE, displayMessage: "Ed25519Scheme.encrypt: mismatch between expected types (Uint8Array, Ed25519PublicComponent)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Scheme.ts:55" });
         }
         return encryptingFunc;
     }
@@ -59,7 +61,7 @@ export default class Ed25519Scheme extends BaseScheme{
             if(cipher instanceof Uint8Array && component instanceof Ed25519PrivateComponent){
                 return await ElGamal.decryptDataRaw(cipher, component.priv);
             }
-            else throw Error("Mismatch between expected types (Uint8Array, Ed25519PrivateComponent)");
+            else throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_TYPE, displayMessage: "Ed25519Scheme.decrypt: mismatch between expected types (Uint8Array, Ed25519PrivateComponent)", source: "tide-js/Cryptide/Components/Schemes/Ed25519/Ed25519Scheme.ts:64" });
         }
         return decryptingFunc;
     }

--- a/Cryptide/Ed25519.ts
+++ b/Cryptide/Ed25519.ts
@@ -40,6 +40,8 @@
 // 
 import { base64ToBytes, bytesToBase64 } from "./Serialization";
 import { SHA256_Digest } from "./Hashing/Hash";
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
 
 
 const P = 2n ** 255n - 19n; // ed25519 is twisted edwards curve
@@ -58,7 +60,11 @@ const CURVE = {
     d: _d, // -(121665/121666) mod p
     p: P, n: N, h: 8, Gx: Gx, Gy: Gy // field prime, curve (group) order, cofactor
 };
-const err = (m = '') => { throw new Error(m); }; // error helper, messes-up stack trace
+// error helper: route all sites through TideError under CRYPTO_ED25519_BAD_POINT.
+// Messages are upstream noble-curves classifier strings (e.g. "bad y coord 3",
+// "Uint8Array of valid length expected") which carry only validation metadata,
+// never raw scalars/points/keys.
+const err = (m = '') => { throw new TideError({ code: TideJsErrorCodes.CRYPTO_ED25519_BAD_POINT, displayMessage: m || "ed25519: bad input", source: "tide-js/Cryptide/Ed25519.ts:err" }); };
 const isS = (s) => typeof s === 'string'; // is string
 const isB = (s) => typeof s === 'bigint'; // is bigint
 const isu8 = (a) => (a instanceof Uint8Array || (ArrayBuffer.isView(a) && a.constructor.name === 'Uint8Array'));
@@ -126,7 +132,7 @@ class Point {
         const { a, d } = CURVE;
         const p = this;
         if (p.is0())
-            throw new Error('bad point: ZERO'); // TODO: optimize, with vars below?
+            throw new TideError({ code: TideJsErrorCodes.CRYPTO_ED25519_BAD_POINT, displayMessage: "bad point: ZERO", source: "tide-js/Cryptide/Ed25519.ts:133" }); // TODO: optimize, with vars below?
         // Equation in affine coordinates: ax² + y² = 1 + dx²y²
         // Equation in projective coordinates (X/Z, Y/Z, Z):  (aX² + Y²)Z² = Z⁴ + dX²Y²
         const { ex: X, ey: Y, ez: Z, et: T } = p;
@@ -138,12 +144,12 @@ class Point {
         const left = M(Z2 * M(aX2 + Y2)); // (aX² + Y²)Z²
         const right = M(Z4 + M(d * M(X2 * Y2))); // Z⁴ + dX²Y²
         if (left !== right)
-            throw new Error('bad point: equation left != right (1)');
+            throw new TideError({ code: TideJsErrorCodes.CRYPTO_ED25519_BAD_POINT, displayMessage: "bad point: equation left != right (1)", source: "tide-js/Cryptide/Ed25519.ts:145" });
         // In Extended coordinates we also have T, which is x*y=T/Z: check X*Y == Z*T
         const XY = M(X * Y);
         const ZT = M(Z * T);
         if (XY !== ZT)
-            throw new Error('bad point: equation left != right (2)');
+            throw new TideError({ code: TideJsErrorCodes.CRYPTO_ED25519_BAD_POINT, displayMessage: "bad point: equation left != right (2)", source: "tide-js/Cryptide/Ed25519.ts:150" });
         return true;
     }
     equals(other) {
@@ -286,9 +292,9 @@ const concatB = (...arrs) => {
     return r;
 };
 const invert = (num, md) => {
-    if(!isB(num)) throw Error("Expecting bigint");
+    if(!isB(num)) throw new TideError({ code: TideJsErrorCodes.CRYPTO_INVALID_BIGINT_INPUT, displayMessage: `invert: expected bigint (got ${typeof num})`, source: "tide-js/Cryptide/Ed25519.ts:295" });
     if (num === 0n || md <= 0n)
-        err('no inverse n=' + num + ' mod=' + md); // no neg exponent for now
+        err(`no inverse (num is ${num === 0n ? "zero" : "non-zero"}, mod is ${md <= 0n ? "non-positive" : "positive"})`); // no neg exponent for now
     let a = M(num, md), b = md, x = 0n, y = 1n, u = 1n, v = 0n;
     while (a !== 0n) { // uses euclidean gcd algorithm
         const q = b / a, r = b % a; // not constant-time

--- a/Cryptide/Encryption/AES.ts
+++ b/Cryptide/Encryption/AES.ts
@@ -16,6 +16,8 @@
 //
 
 import { base64ToBytes, BigIntToByteArray, bytesToBase64, ConcatUint8Arrays } from "../Serialization";
+import { TideError } from "../../Errors/TideError";
+import { TideJsErrorCodes } from "../../Errors/codes";
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();
@@ -39,7 +41,7 @@ export async function encryptData(secretData: string | Uint8Array, key: Uint8Arr
     } else if(typeof(key) === 'bigint'){
         aesKey = BigIntToByteArray(key);
     }else{
-        throw Error("Unsupported key type");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_AES_UNSUPPORTED_KEY_TYPE, displayMessage: `Unsupported key type (expected Uint8Array | string | bigint, got ${typeof key})`, source: "tide-js/Cryptide/Encryption/AES.ts:42" });
     }
     const encoded = typeof (secretData) === 'string' ? enc.encode(secretData) : secretData;
     const encrypted = await encryptDataRawOutput(encoded, aesKey);
@@ -69,7 +71,7 @@ export async function decryptData(encryptedData: string, key: Uint8Array | bigin
         aesKey = BigIntToByteArray(key);
     }
     else{
-        throw Error("Unsupported key type");
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_AES_UNSUPPORTED_KEY_TYPE, displayMessage: `Unsupported key type (expected Uint8Array | string | bigint, got ${typeof key})`, source: "tide-js/Cryptide/Encryption/AES.ts:72" });
     }
     const encryptedDataBuff = base64ToBytes(encryptedData);
     const decryptedContent = await decryptDataRawOutput(encryptedDataBuff, aesKey)

--- a/Cryptide/Encryption/DH.ts
+++ b/Cryptide/Encryption/DH.ts
@@ -18,6 +18,8 @@
 import { Point } from "../Ed25519";
 import { SHA256_Digest } from "../Hashing/Hash";
 import { BigIntFromByteArray, base64ToBytes } from "../Serialization";
+import { TideError } from "../../Errors/TideError";
+import { TideJsErrorCodes } from "../../Errors/codes";
 
 export async function computeSharedKey(pub: Point, priv: bigint | string | Uint8Array){
     let privNum;
@@ -27,7 +29,7 @@ export async function computeSharedKey(pub: Point, priv: bigint | string | Uint8
         privNum = BigIntFromByteArray(priv);
     }else if(typeof(priv) == "bigint"){
         privNum = priv;
-    }else throw Error("Unknown Type");
+    }else throw new TideError({ code: TideJsErrorCodes.CRYPTO_DH_UNSUPPORTED_PRIV_TYPE, displayMessage: `Unknown Type (expected bigint | string | Uint8Array, got ${typeof priv})`, source: "tide-js/Cryptide/Encryption/DH.ts:30" });
     return await SHA256_Digest(pub.mul(privNum).toRawBytes());
 }
 

--- a/Cryptide/Hashing/H2P.ts
+++ b/Cryptide/Hashing/H2P.ts
@@ -43,6 +43,8 @@ import { Point } from "../Ed25519";
 import { ConcatUint8Arrays, BigIntFromByteArray } from "../Serialization";
 import { mod, mod_inv } from "../Math";
 import { SHA512_Digest } from "./Hash";
+import { TideError } from "../../Errors/TideError";
+import { TideJsErrorCodes } from "../../Errors/codes";
 
 const curveP = BigInt("57896044618658097711785492504343953926634992332820282019728792003956564819949");
 
@@ -77,7 +79,7 @@ function add_nums(num1,num2,modulus=curveP){return mod(num1+num2,modulus);}; //a
 function multiply_nums(num1,num2,modulus=curveP){return mod(BigInt(num1*num2),modulus);}; //multiplies numbers then reduces them below curveP
 function to_the_power_of(number,power,modulus=curveP){
     if (power < _0n)
-        throw new Error('Expected power > 0');
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_HASH_TO_POINT_INVALID_INPUT, displayMessage: "to_the_power_of: expected power > 0", source: "tide-js/Cryptide/Hashing/H2P.ts:82" });
     if (power === _0n)
         return _1n;
     if (power === _1n)
@@ -161,7 +163,7 @@ function map_to_curve_elligator2_edwards25519_(u) {
 
 function i2osp(value, length) {
     if (value < 0 || value >= 1 << (8 * length)) {
-        throw new Error(`bad I2OSP call: value=${value} length=${length}`);
+        throw new TideError({ code: TideJsErrorCodes.CRYPTO_HASH_TO_POINT_INVALID_INPUT, displayMessage: `i2osp: value out of range for ${length}-byte encoding`, source: "tide-js/Cryptide/Hashing/H2P.ts:166" });
     }
     const res: any = Array.from({ length }).fill(0);
     for (let i = length - 1; i >= 0; i--) {
@@ -183,7 +185,7 @@ async function expand_message_xmd(msg: Uint8Array, DST: Uint8Array, len_in_bytes
     const b_in_bytes = 64;
     const r_in_bytes = 128;
     const ell = Math.ceil(len_in_bytes/b_in_bytes);
-    if (ell > 255) throw new Error('Invalid xmd length');
+    if (ell > 255) throw new TideError({ code: TideJsErrorCodes.CRYPTO_HASH_TO_POINT_INVALID_INPUT, displayMessage: `expand_message_xmd: invalid length (ell=${ell} > 255)`, source: "tide-js/Cryptide/Hashing/H2P.ts:188" });
     const DST_prime = ConcatUint8Arrays([DST, i2osp(DST.length, 1)]);
     const Z_pad = i2osp(0,r_in_bytes);
     const len_in_bytes_str = i2osp(len_in_bytes,2);

--- a/Cryptide/Interpolation.ts
+++ b/Cryptide/Interpolation.ts
@@ -18,6 +18,8 @@
 import { mod, mod_inv } from "./Math";
 import { Point, CURVE } from "./Ed25519";
 import { Ed25519PublicComponent } from "./Components/Schemes/Ed25519/Ed25519Components";
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
 
 export function GetLi(xi: bigint, xs: bigint[], m: bigint = CURVE.n): bigint {
     var li = xs.filter(xj => xj != xi)
@@ -41,7 +43,7 @@ export function AggregatePublicComponents(points: Ed25519PublicComponent[]){
 
 export function AggregatePublicComponentArrays(pointArrays: Ed25519PublicComponent[][]){
     const arrayDepth = pointArrays[0].length;
-    if(!pointArrays.every(array => array.length == arrayDepth)) throw Error("Inconsistent amount of array depths");
+    if(!pointArrays.every(array => array.length == arrayDepth)) throw new TideError({ code: TideJsErrorCodes.CRYPTO_ORK_ARRAY_LENGTH_MISMATCH, displayMessage: `Inconsistent amount of array depths (expected ${arrayDepth} across ${pointArrays.length} arrays)`, source: "tide-js/Cryptide/Interpolation.ts:46" });
     return pointArrays[0].map((_, i) => AggregatePublicComponents(pointArrays.map(array => array[i])));
 }
 
@@ -50,7 +52,7 @@ export function AggregatePublicComponentArrays(pointArrays: Ed25519PublicCompone
  */
 export function AggregatePointArrays(pointArrays: Point[][]){
     const arrayDepth = pointArrays[0].length;
-    if(!pointArrays.every(array => array.length == arrayDepth)) throw Error("Inconsistent amount of array depths");
+    if(!pointArrays.every(array => array.length == arrayDepth)) throw new TideError({ code: TideJsErrorCodes.CRYPTO_ORK_ARRAY_LENGTH_MISMATCH, displayMessage: `Inconsistent amount of array depths (expected ${arrayDepth} across ${pointArrays.length} arrays)`, source: "tide-js/Cryptide/Interpolation.ts:55" });
     return pointArrays[0].map((_, i) => AggregatePoints(pointArrays.map(array => array[i])));
 }
 /**

--- a/Cryptide/Math.ts
+++ b/Cryptide/Math.ts
@@ -20,6 +20,8 @@ import { BigIntFromByteArray, BigIntToByteArray } from "../Cryptide/Serializatio
 import { SHA256_Digest } from "./Hashing/Hash";
 import TideKey from "./TideKey";
 import { computeSharedKey, generateECDHi } from "./Encryption/DH";
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
 
 const _0n = BigInt(0);
 const _1n = BigInt(1);
@@ -72,7 +74,7 @@ export function Min(arr: number[]){
 
 export function mod_inv(number: bigint, modulo: bigint = CURVE.n): bigint {
 	if (number === _0n || modulo <= _0n) {
-		throw new Error(`invert: expected positive integers, got n=${number} mod=${modulo}`);
+		throw new TideError({ code: TideJsErrorCodes.CRYPTO_INVERSE_NOT_EXIST, displayMessage: `mod_inv: expected positive integers (number is ${number === _0n ? "zero" : "non-zero"}, modulo is ${modulo <= _0n ? "non-positive" : "positive"})`, source: "tide-js/Cryptide/Math.ts:77" });
 	}
 	let a = mod(number, modulo);
 	let b = modulo;
@@ -87,7 +89,7 @@ export function mod_inv(number: bigint, modulo: bigint = CURVE.n): bigint {
 		b = a, a = r, x = u, y = v, u = m, v = n;
 	}
 	const gcd = b;
-	if (gcd !== _1n) throw new Error('invert: does not exist');
+	if (gcd !== _1n) throw new TideError({ code: TideJsErrorCodes.CRYPTO_INVERSE_NOT_EXIST, displayMessage: "mod_inv: modular inverse does not exist (gcd != 1)", source: "tide-js/Cryptide/Math.ts:92" });
 	return mod(x, modulo);
 }
 

--- a/Cryptide/Serialization.ts
+++ b/Cryptide/Serialization.ts
@@ -29,7 +29,7 @@ export function writeInt64LittleEndian(value: bigint) {
     const INT64_MAX = 9223372036854775807n;  // 2^63 - 1
 
     if (value < INT64_MIN || value > INT64_MAX) {
-        throw new RangeError("Value is out of range for a 64-bit signed integer.");
+        throw new TideError({ code: TideJsErrorCodes.SERIAL_LENGTH_OUT_OF_RANGE, displayMessage: "Value is out of range for a 64-bit signed integer.", source: "tide-js/Cryptide/Serialization.ts:32" });
     }
 
     const bytes = new Uint8Array(8);
@@ -41,7 +41,7 @@ export function writeInt64LittleEndian(value: bigint) {
 }
 export function readInt64LittleEndian(bytes: Uint8Array) {
     if (bytes.length !== 8) {
-        throw new Error("Invalid byte array length. Expected 8 bytes.");
+        throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_LENGTH, displayMessage: `Invalid byte array length. Expected 8 bytes, got ${bytes.length}.`, source: "tide-js/Cryptide/Serialization.ts:44" });
     }
 
     let value = 0n;
@@ -64,7 +64,7 @@ export class AuthorizerPack{
 		const isUint8Like = d && (d instanceof Uint8Array ||
 			(ArrayBuffer.isView(d) && d.constructor?.name === 'Uint8Array') ||
 			(typeof d === 'object' && typeof d.length === 'number' && d.buffer instanceof ArrayBuffer));
-		if(!isUint8Like) throw Error("Data must be byte array");
+		if(!isUint8Like) throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_TYPE, displayMessage: "Data must be byte array", source: "tide-js/Cryptide/Serialization.ts:67" });
 		this.AuthFlow = StringFromUint8Array(GetValue(data, 0));
 		this.Authorizer = new GVRK_Pack(GetValue(data, 1));
 
@@ -126,9 +126,9 @@ export function CreateTideMemoryFromArray(datas: Uint8Array[]){
     return mem;
 }
 export function WriteValue(memory: Uint8Array, index: number, value: Uint8Array) {
-    if (index < 0) throw new Error("Index cannot be less than 0");
-    if (index === 0) throw new Error("Use CreateTideMemory to set value at index 0");
-    if (memory.length < 4 + value.length) throw new Error("Could not write to memory. Memory too small for this value");
+    if (index < 0) throw new TideError({ code: TideJsErrorCodes.MEM_NEGATIVE_INDEX, displayMessage: "Index cannot be less than 0", source: "tide-js/Cryptide/Serialization.ts:129" });
+    if (index === 0) throw new TideError({ code: TideJsErrorCodes.MEM_INDEX_ZERO_RESERVED, displayMessage: "Use CreateTideMemory to set value at index 0", source: "tide-js/Cryptide/Serialization.ts:130" });
+    if (memory.length < 4 + value.length) throw new TideError({ code: TideJsErrorCodes.MEM_BUFFER_OVERFLOW, displayMessage: `Could not write to memory. Memory too small for this value (memory.length=${memory.length}, required>=${4 + value.length})`, source: "tide-js/Cryptide/Serialization.ts:131" });
 
     const dataView = new DataView(memory.buffer);
     let dataLocationIndex = 4; // Start after the version number
@@ -162,7 +162,7 @@ export function WriteValue(memory: Uint8Array, index: number, value: Uint8Array)
     // Check if data has already been written to this index
     const existingLength = dataView.getInt32(dataLocationIndex, true);
     if (existingLength !== 0) {
-        throw new Error("Data has already been written to this index");
+        throw new TideError({ code: TideJsErrorCodes.MEM_INDEX_ALREADY_WRITTEN, displayMessage: `Data has already been written to this index (index=${index}, offset=${dataLocationIndex}, existingLength=${existingLength})`, source: "tide-js/Cryptide/Serialization.ts:165" });
     }
 
     // Write data length of value at current position
@@ -261,8 +261,8 @@ export async function EdPointToJWK(p: Point){
 export function DeserializeTIDE_KEY(key: string, prefix: string){
 	const header = key.substring(0, 8);
 	const data = base64ToBytes(key.substring(8, key.length));
-	if(header != "tide" + prefix + "key") throw Error("Unexpected header in deserialization");
-	if(data.length != 32) throw Error("Unexpected key length in deserialization");
+	if(header != "tide" + prefix + "key") throw new TideError({ code: TideJsErrorCodes.SERIAL_UNEXPECTED_HEADER, displayMessage: `Unexpected header in deserialization (expected "tide${prefix}key")`, source: "tide-js/Cryptide/Serialization.ts:264" });
+	if(data.length != 32) throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_LENGTH, displayMessage: `Unexpected key length in deserialization (expected 32 bytes, got ${data.length})`, source: "tide-js/Cryptide/Serialization.ts:265" });
 	return BigIntFromByteArray(data);
 }
 
@@ -291,7 +291,7 @@ export function ConcatUint8Arrays(arrays: Uint8Array[]) {
 
 export function XOR(array1: Uint8Array, array2: Uint8Array){
 	if (array1.length !== array2.length) {
-        throw new Error('Arrays have different lengths, cannot XOR them.');
+        throw new TideError({ code: TideJsErrorCodes.SERIAL_LENGTH_MISMATCH, displayMessage: `Arrays have different lengths, cannot XOR them. (array1.length=${array1.length}, array2.length=${array2.length})`, source: "tide-js/Cryptide/Serialization.ts:294" });
     }
     let result = new Uint8Array(array1.length);
     for (let i = 0; i < array1.length; i++) {
@@ -355,7 +355,7 @@ export class Byte {
 	 */
 	static fromNumber(number: number): Byte {
 		if (number < 0 || number > 255) {
-			throw Error("Number must be between 0 and 255"); // Adjusted the range check
+			throw new TideError({ code: TideJsErrorCodes.SERIAL_LENGTH_OUT_OF_RANGE, displayMessage: `Number must be between 0 and 255 (got ${number})`, source: "tide-js/Cryptide/Serialization.ts:358" }); // Adjusted the range check
 		}
 		let byte = new Byte();
 		let binaryString = number.toString(2).padStart(8, '0'); // Pad the string to ensure 8 bits
@@ -376,7 +376,7 @@ export function getBytesFromInt16(schemeInt: number) {
 }
 export function numberToUint8Array(num: number, len: number = -1) {
 	if (num < 0 || !Number.isInteger(num)) {
-        throw new Error('Number must be a non-negative integer.');
+        throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_TYPE, displayMessage: `Number must be a non-negative integer. (got ${num})`, source: "tide-js/Cryptide/Serialization.ts:379" });
     }
 
     if (num === 0) return new Uint8Array([0]);
@@ -397,7 +397,7 @@ export function numberToUint8Array(num: number, len: number = -1) {
 }
 export function Uint8ArrayToNumber(byteArray: Uint8Array){
 	if (!(byteArray instanceof Uint8Array)) {
-        throw new Error('Input must be a Uint8Array.');
+        throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_TYPE, displayMessage: `Input must be a Uint8Array. (got ${typeof byteArray})`, source: "tide-js/Cryptide/Serialization.ts:400" });
     }
 
     let num = 0;
@@ -495,7 +495,7 @@ export function uint8ArrayToBitArray(byteArray: Uint8Array) {
 }
 export function Hex2Bytes(string: string): Uint8Array {
     const hexRegex = /^0x[0-9A-Fa-f]+$|^[0-9A-Fa-f]+$/;
-    if (!hexRegex.test(string)) throw Error("Invalid Hex");
+    if (!hexRegex.test(string)) throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_HEX, displayMessage: "Invalid Hex", source: "tide-js/Cryptide/Serialization.ts:498" });
 
     const normal = string.length % 2 ? "0" + string : string; // Make even length
     const bytes = new Uint8Array(normal.length / 2);
@@ -552,11 +552,11 @@ const base64codes = [
 
 function getBase64Code(charCode) {
 	if (charCode >= base64codes.length) {
-		throw new Error("Unable to parse base64 string.");
+		throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_BASE64, displayMessage: `Unable to parse base64 string. (charCode ${charCode} >= base64codes.length ${base64codes.length})`, source: "tide-js/Cryptide/Serialization.ts:555" });
 	}
 	const code = base64codes[charCode];
 	if (code === 255) {
-		throw new Error("Unable to parse base64 string.");
+		throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_BASE64, displayMessage: `Unable to parse base64 string. (charCode ${charCode} is not a valid base64 character)`, source: "tide-js/Cryptide/Serialization.ts:559" });
 	}
 	return code;
 }
@@ -585,13 +585,13 @@ export function bytesToBase64(bytes: Uint8Array): string {
 
 export function base64ToBytes(str: string): Uint8Array {
 	const base64Regex = /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/;
-    if(!base64Regex.test(str)) throw Error("Not valid base64");
+    if(!base64Regex.test(str)) throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_BASE64, displayMessage: "Not valid base64", source: "tide-js/Cryptide/Serialization.ts:588" });
 	if (str.length % 4 !== 0) {
-		throw new Error("Unable to parse base64 string.");
+		throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_BASE64, displayMessage: `Unable to parse base64 string. (length ${str.length} is not a multiple of 4)`, source: "tide-js/Cryptide/Serialization.ts:590" });
 	}
 	const index = str.indexOf("=");
 	if (index !== -1 && index < str.length - 2) {
-		throw new Error("Unable to parse base64 string.");
+		throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_BASE64, displayMessage: `Unable to parse base64 string. (padding '=' at offset ${index} is not within the last 2 characters)`, source: "tide-js/Cryptide/Serialization.ts:594" });
 	}
 	let missingOctets = str.endsWith("==") ? 2 : str.endsWith("=") ? 1 : 0,
 		n = str.length,

--- a/Cryptide/Signing/TideSignature.ts
+++ b/Cryptide/Signing/TideSignature.ts
@@ -17,6 +17,8 @@
 
 import { Serialization } from "../index";
 import { ConcatUint8Arrays, numberToUint8Array, StringToUint8Array } from "../Serialization";
+import { TideError } from "../../Errors/TideError";
+import { TideJsErrorCodes } from "../../Errors/codes";
 
 export class TideSignatureFormat{
     Name: string;
@@ -30,7 +32,7 @@ export class TideSignatureFormat{
             this.Message = StringToUint8Array(message);
         }else if(message instanceof Uint8Array) {
             this.Message = message.slice();
-        }else throw Error("Unknown type provided");
+        }else throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_TYPE, displayMessage: `TideSignatureFormat: expected string or Uint8Array (got ${typeof message})`, source: "tide-js/Cryptide/Signing/TideSignature.ts:35" });
     }
     format(): Uint8Array {
         return ConcatUint8Arrays([StringToUint8Array(this.Header()), this.Message, StringToUint8Array(this.Footer())]);

--- a/Cryptide/TideKey.ts
+++ b/Cryptide/TideKey.ts
@@ -24,6 +24,8 @@ import { SchemeType } from "./Components/Schemes/SchemeRegistry";
 import { computeSharedKey } from "./Encryption/DH";
 import { GetPublic, mod, RandomBigInt } from "./Math";
 import { BigIntFromByteArray, BigIntToByteArray, Bytes2Hex, bytesToBase64 } from "./Serialization";
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
 
 export default class TideKey{
 
@@ -42,15 +44,15 @@ export default class TideKey{
 
     constructor(c: BaseComponent){
         if(c instanceof BaseComponent) this.component = c;
-        else throw Error("Expecting object derived from BaseComponent");
+        else throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_KEY, displayMessage: "Expecting object derived from BaseComponent", source: "tide-js/Cryptide/TideKey.ts:45" });
     }
     get_private_component(): BasePrivateComponent {
-        if(!hasOwnInstanceMethod(this.component, "GetPrivate") && !(this.component instanceof BasePrivateComponent)) throw Error("Cannot generate or find private component");
+        if(!hasOwnInstanceMethod(this.component, "GetPrivate") && !(this.component instanceof BasePrivateComponent)) throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_KEY, displayMessage: "Cannot generate or find private component", source: "tide-js/Cryptide/TideKey.ts:48" });
         this.privateComponent = this.component instanceof BasePrivateComponent ? this.component : (this.component as any).GetPrivate();
         return this.privateComponent;
     }
     get_public_component(): BasePublicComponent {
-        if(!hasOwnInstanceMethod(this.component, "GetPublic") && !(this.component instanceof BasePublicComponent)) throw Error("Cannot generate or find public component");
+        if(!hasOwnInstanceMethod(this.component, "GetPublic") && !(this.component instanceof BasePublicComponent)) throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_KEY, displayMessage: "Cannot generate or find public component", source: "tide-js/Cryptide/TideKey.ts:53" });
         this.publicComponent = this.component instanceof BasePublicComponent ? this.component : (this.component as any).GetPublic();
         return this.publicComponent;
     }
@@ -75,7 +77,7 @@ export default class TideKey{
 
     async prepVouchersReq(gORKn){
         // Ensure scheme is Ed25519 for tide vouchers
-        if(this.component.Scheme !== Ed25519Scheme) throw Error("Cannot execute prepVouchersReq on a non Ed25519 key");
+        if(this.component.Scheme !== Ed25519Scheme) throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_KEY, displayMessage: "Cannot execute prepVouchersReq on a non Ed25519 key", source: "tide-js/Cryptide/TideKey.ts:78" });
         let blurKeyPub = [];
         for(let i = 0; i< gORKn.length; i++){
             const z = mod(BigIntFromByteArray(await computeSharedKey(gORKn[i], this.get_private_component().priv)));

--- a/Cryptide/TideMemoryObjects.ts
+++ b/Cryptide/TideMemoryObjects.ts
@@ -19,11 +19,13 @@ import { CreateTideMemory, writeInt64LittleEndian, WriteValue } from "./Serializ
 import { Utils } from "../index";
 import { Ed25519PublicComponent } from "./Components/Schemes/Ed25519/Ed25519Components";
 import { AuthorizerSignatureFormat } from "./Signing/TideSignature";
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
 
 export function CreateVRKPackage(gvrk: Ed25519PublicComponent, expiry: number | bigint){
     const serializedgvrk = gvrk.Serialize().ToBytes();
     const ex = typeof expiry == "bigint" ? expiry : BigInt(expiry);
-    if(ex < BigInt(Utils.CurrentTime() + 5)) throw Error("Expiry must be at least 5 seconds into future");
+    if(ex < BigInt(Utils.CurrentTime() + 5)) throw new TideError({ code: TideJsErrorCodes.MODEL_VALUE_OUT_OF_RANGE, displayMessage: "Expiry must be at least 5 seconds into future", source: "tide-js/Cryptide/TideMemoryObjects.ts:26" });
     const time_b = writeInt64LittleEndian(ex);
     const vrk_pack = CreateTideMemory(serializedgvrk,
         4 + 4 + serializedgvrk.length + time_b.length

--- a/Errors/codes.ts
+++ b/Errors/codes.ts
@@ -104,6 +104,18 @@ export const TideJsErrorCodes = Object.freeze({
     CRYPTO_AES_UNSUPPORTED_KEY_TYPE: "TIDE-TIDEJS-CRYPTO-AES_UNSUPPORTED_KEY_TYPE",
     /** DH `computeSharedKey` called with a private value of an unsupported JS type. */
     CRYPTO_DH_UNSUPPORTED_PRIV_TYPE: "TIDE-TIDEJS-CRYPTO-DH_UNSUPPORTED_PRIV_TYPE",
+    /** An Ed25519 Point failed an on-curve / equality / non-ZERO sanity check. */
+    CRYPTO_ED25519_BAD_POINT: "TIDE-TIDEJS-CRYPTO-ED25519_BAD_POINT",
+    /** Modular inverse does not exist (gcd != 1, or invert of 0 / non-positive modulus). */
+    CRYPTO_INVERSE_NOT_EXIST: "TIDE-TIDEJS-CRYPTO-INVERSE_NOT_EXIST",
+    /** A low-level crypto primitive received a value of an unexpected JS type (e.g. `invert` expected a bigint). */
+    CRYPTO_INVALID_BIGINT_INPUT: "TIDE-TIDEJS-CRYPTO-INVALID_BIGINT_INPUT",
+    /** Hash-to-Point (RFC 9380 expand_message_xmd / i2osp) received an out-of-range input. */
+    CRYPTO_HASH_TO_POINT_INVALID_INPUT: "TIDE-TIDEJS-CRYPTO-HASH_TO_POINT_INVALID_INPUT",
+
+    // --- Signature -------------------------------------------------------
+    /** Non-blind signature verification failed (e.g. Ed25519Scheme `verifyingFunc`). */
+    SIG_VERIFY_FAILED: "TIDE-TIDEJS-SIG-VERIFY_FAILED",
 
     // --- Serialization helpers -----------------------------------------
     /** A numeric value cannot be represented in the requested width (e.g. > Int64 / > 255 byte). */
@@ -136,6 +148,18 @@ export const TideJsErrorCodes = Object.freeze({
     MODEL_INVALID_KEY: "TIDE-TIDEJS-MODEL-INVALID_KEY",
     /** A model field's value was not in the allowed range (e.g. VRK expiry too close to now). */
     MODEL_VALUE_OUT_OF_RANGE: "TIDE-TIDEJS-MODEL-VALUE_OUT_OF_RANGE",
+    /** ModelRegistry could not resolve a sign-request name:version to a builder (unknown model id). */
+    MODEL_UNKNOWN_MODEL: "TIDE-TIDEJS-MODEL-UNKNOWN_MODEL",
+    /** A PolicyParameters entry carries an unrecognised type tag (e.g. not str/num/bnum/bln/byt). */
+    MODEL_UNKNOWN_PARAM_TYPE: "TIDE-TIDEJS-MODEL-UNKNOWN_PARAM_TYPE",
+    /** `Policy.getParameter` was asked for a parameter key that does not exist on the policy. */
+    MODEL_PARAM_NOT_FOUND: "TIDE-TIDEJS-MODEL-PARAM_NOT_FOUND",
+    /** A developer-only invariant was violated inside a Policy version handler (should be unreachable in production). */
+    MODEL_DEV_ERROR: "TIDE-TIDEJS-MODEL-DEV_ERROR",
+    /** A request (e.g. BaseTideRequest) was used before a required field (authorizer / authorization / cert) had been added. */
+    MODEL_REQUEST_NOT_INITIALIZED: "TIDE-TIDEJS-MODEL-REQUEST_NOT_INITIALIZED",
+    /** A serialized model header carried an unsupported version tag (Policy / SerializedField). */
+    MODEL_VERSION_MISMATCH: "TIDE-TIDEJS-MODEL-VERSION_MISMATCH",
 
     // --- TideMemory guards ---------------------------------------------
     /** Caller supplied a negative index to a TideMemory helper. */

--- a/Errors/codes.ts
+++ b/Errors/codes.ts
@@ -86,6 +86,70 @@ export const TideJsErrorCodes = Object.freeze({
      * upstream `code` verbatim instead.
      */
     PROXY_UPSTREAM_ERROR: "TIDE-TIDEJS-PROXY-UPSTREAM_ERROR",
+
+    // --- Network (additional) -------------------------------------------
+    /** A non-TideError value was thrown from the fetch pipeline — caught and tagged for the recent-requests buffer. */
+    NET_UNKNOWN: "TIDE-TIDEJS-NET-UNKNOWN",
+
+    // --- Cryptide / low-level crypto ------------------------------------
+    /** A `BaseComponent` abstract method (e.g. `Add`/`Multiply`/`Scheme`) was invoked but not implemented on the concrete subclass. */
+    CRYPTO_NOT_IMPLEMENTED: "TIDE-TIDEJS-CRYPTO-NOT_IMPLEMENTED",
+    /** Two components were combined whose schemes / component-types do not match. */
+    CRYPTO_COMPONENT_MISMATCH: "TIDE-TIDEJS-CRYPTO-COMPONENT_MISMATCH",
+    /** Scheme / component-type registry lookup failed (unknown scheme or component type). */
+    CRYPTO_UNKNOWN_COMPONENT_TYPE: "TIDE-TIDEJS-CRYPTO-UNKNOWN_COMPONENT_TYPE",
+    /** A serialized component could not be parsed into bytes (neither hex nor base64). */
+    CRYPTO_DESERIALIZE_FAILED: "TIDE-TIDEJS-CRYPTO-DESERIALIZE_FAILED",
+    /** AES encrypt/decrypt called with a key of an unsupported JS type. */
+    CRYPTO_AES_UNSUPPORTED_KEY_TYPE: "TIDE-TIDEJS-CRYPTO-AES_UNSUPPORTED_KEY_TYPE",
+    /** DH `computeSharedKey` called with a private value of an unsupported JS type. */
+    CRYPTO_DH_UNSUPPORTED_PRIV_TYPE: "TIDE-TIDEJS-CRYPTO-DH_UNSUPPORTED_PRIV_TYPE",
+
+    // --- Serialization helpers -----------------------------------------
+    /** A numeric value cannot be represented in the requested width (e.g. > Int64 / > 255 byte). */
+    SERIAL_LENGTH_OUT_OF_RANGE: "TIDE-TIDEJS-SERIAL-LENGTH_OUT_OF_RANGE",
+    /** The supplied argument was not of the expected JS type (e.g. expected Uint8Array, got something else). */
+    SERIAL_INVALID_TYPE: "TIDE-TIDEJS-SERIAL-INVALID_TYPE",
+    /** A serialization helper found data already present where an empty slot was expected. */
+    SERIAL_INDEX_OOB: "TIDE-TIDEJS-SERIAL-INDEX_OOB",
+    /** A serialization write would have exceeded the destination buffer's capacity. */
+    SERIAL_BUFFER_OVERFLOW: "TIDE-TIDEJS-SERIAL-BUFFER_OVERFLOW",
+    /** A length-tagged input did not match the expected length (e.g. TIDE_KEY blob != 32 bytes). */
+    SERIAL_INVALID_LENGTH: "TIDE-TIDEJS-SERIAL-INVALID_LENGTH",
+    /** A header / magic value did not match the expected token (e.g. "tidexxxkey" prefix mismatch). */
+    SERIAL_UNEXPECTED_HEADER: "TIDE-TIDEJS-SERIAL-UNEXPECTED_HEADER",
+    /** A hex string failed regex validation. */
+    SERIAL_INVALID_HEX: "TIDE-TIDEJS-SERIAL-INVALID_HEX",
+    /** A base64 string failed validation or decoding. */
+    SERIAL_INVALID_BASE64: "TIDE-TIDEJS-SERIAL-INVALID_BASE64",
+    /** Two operand arrays had unequal lengths where equal lengths were required (e.g. XOR). */
+    SERIAL_LENGTH_MISMATCH: "TIDE-TIDEJS-SERIAL-LENGTH_MISMATCH",
+
+    // --- Model validation ----------------------------------------------
+    /** A model field (Doken/AuthRequest/TideKey) failed a shape/type guard during construction or parsing. */
+    MODEL_INVALID_FIELD: "TIDE-TIDEJS-MODEL-INVALID_FIELD",
+    /** A model header value (e.g. Doken `alg`/`typ`) did not match the expected value. */
+    MODEL_UNEXPECTED_HEADER: "TIDE-TIDEJS-MODEL-UNEXPECTED_HEADER",
+    /** A model expected a specific shape (e.g. Doken = 3 parts) and the input did not conform. */
+    MODEL_INVALID_SHAPE: "TIDE-TIDEJS-MODEL-INVALID_SHAPE",
+    /** A TideKey was constructed/derived from a component that does not satisfy the required interface. */
+    MODEL_INVALID_KEY: "TIDE-TIDEJS-MODEL-INVALID_KEY",
+    /** A model field's value was not in the allowed range (e.g. VRK expiry too close to now). */
+    MODEL_VALUE_OUT_OF_RANGE: "TIDE-TIDEJS-MODEL-VALUE_OUT_OF_RANGE",
+
+    // --- TideMemory guards ---------------------------------------------
+    /** Caller supplied a negative index to a TideMemory helper. */
+    MEM_NEGATIVE_INDEX: "TIDE-TIDEJS-MEM-NEGATIVE_INDEX",
+    /** Caller attempted to overwrite the zero-index slot via WriteValue (must use Create). */
+    MEM_INDEX_ZERO_RESERVED: "TIDE-TIDEJS-MEM-INDEX_ZERO_RESERVED",
+    /** TideMemory write would exceed the destination buffer's capacity. */
+    MEM_BUFFER_OVERFLOW: "TIDE-TIDEJS-MEM-BUFFER_OVERFLOW",
+    /** TideMemory read sought past the encoded segments of the buffer. */
+    MEM_INDEX_OUT_OF_RANGE: "TIDE-TIDEJS-MEM-INDEX_OUT_OF_RANGE",
+    /** TideMemory buffer is too small to hold even the version header. */
+    MEM_INSUFFICIENT_DATA: "TIDE-TIDEJS-MEM-INSUFFICIENT_DATA",
+    /** TideMemory write attempted at an index already populated with data. */
+    MEM_INDEX_ALREADY_WRITTEN: "TIDE-TIDEJS-MEM-INDEX_ALREADY_WRITTEN",
 } as const);
 
 export type TideJsErrorCode = typeof TideJsErrorCodes[keyof typeof TideJsErrorCodes];

--- a/Models/BaseTideRequest.ts
+++ b/Models/BaseTideRequest.ts
@@ -6,6 +6,8 @@ import { SHA512_Digest } from "../Cryptide/Hashing/Hash";
 import { bytesToBase64, StringToUint8Array } from "../Cryptide/Serialization";
 import { PolicyAuthorizedTideRequestSignatureFormat } from "../Cryptide/Signing/TideSignature";
 import { Serialization } from "../Cryptide";
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
 
 export default class BaseTideRequest {
     static _name: string;
@@ -169,7 +171,7 @@ export default class BaseTideRequest {
     addApproval(doken: Doken, sig: Uint8Array) {
         // Ensure creation authorization has been added
         let res = {};
-        if (!Serialization.TryGetValue(this.authorization, 0, res)) throw Error("Creation authorization hasn't been added yet");
+        if (!Serialization.TryGetValue(this.authorization, 0, res)) throw new TideError({ code: TideJsErrorCodes.MODEL_REQUEST_NOT_INITIALIZED, displayMessage: "BaseTideRequest.addApproval: creation authorization hasn't been added yet", source: "tide-js/Models/BaseTideRequest.ts:174" });
 
         // Deconstruct existing authorization
         let existingSessKeySigs = [];
@@ -241,9 +243,9 @@ export default class BaseTideRequest {
     }
 
     encode() {
-        if (this.authorizer == null) throw Error("Authorizer not added to request");
-        if (this.authorizerCert == null) throw Error("Authorizer cert not provided");
-        if (this.authorization == null) throw Error("Authorize this request first with an authorizer");
+        if (this.authorizer == null) throw new TideError({ code: TideJsErrorCodes.MODEL_REQUEST_NOT_INITIALIZED, displayMessage: "BaseTideRequest.encode: Authorizer not added to request", source: "tide-js/Models/BaseTideRequest.ts:246" });
+        if (this.authorizerCert == null) throw new TideError({ code: TideJsErrorCodes.MODEL_REQUEST_NOT_INITIALIZED, displayMessage: "BaseTideRequest.encode: Authorizer cert not provided", source: "tide-js/Models/BaseTideRequest.ts:247" });
+        if (this.authorization == null) throw new TideError({ code: TideJsErrorCodes.MODEL_REQUEST_NOT_INITIALIZED, displayMessage: "BaseTideRequest.encode: Authorize this request first with an authorizer", source: "tide-js/Models/BaseTideRequest.ts:248" });
 
         const te = new TextEncoder();
         const name_b = te.encode(this.name);
@@ -282,7 +284,7 @@ export default class BaseTideRequest {
 
         // Check name and version in static members if set
         if ((this as any)._name != undefined && (this as any)._version != undefined) {
-            if (name != (this as any)._name || version != (this as any)._version) throw Error("Name and Version in decoded data don't match this object's set name and version.")
+            if (name != (this as any)._name || version != (this as any)._version) throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: "BaseTideRequest.decode: name/version in decoded data don't match this object's set name and version", source: "tide-js/Models/BaseTideRequest.ts:287" });
         }
 
         const expiry = BaseTideRequest.uint8ArrayToUint32LE(d.GetValue(2));
@@ -327,7 +329,7 @@ export default class BaseTideRequest {
 
     private static uint8ArrayToUint32LE(bytes: Uint8Array): number {
         if (bytes.length !== 8) {
-            throw new Error("Expected 8 bytes for a 64-bit value");
+            throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_LENGTH, displayMessage: `BaseTideRequest.uint8ArrayToUint32LE: expected 8 bytes for a 64-bit value (got ${bytes.length})`, source: "tide-js/Models/BaseTideRequest.ts:332" });
         }
 
         // Optional safety check: ensure high 32 bits are zero (no real 64-bit longs passed).

--- a/Models/Doken.ts
+++ b/Models/Doken.ts
@@ -21,6 +21,8 @@ import { Ed25519PublicComponent } from "../Cryptide/Components/Schemes/Ed25519/E
 import { base64ToBase64Url, base64ToBytes, base64UrlToBase64, bytesToBase64, StringFromUint8Array, StringToUint8Array } from "../Cryptide/Serialization";
 import TideKey from "../Cryptide/TideKey";
 import { CurrentTime } from "../Tools/Utils";
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
 
 // Define DokenPayload class first so it can be used in Doken constructor
 class DokenPayload{
@@ -37,33 +39,33 @@ class DokenPayload{
         var s = BaseComponent.DeserializeComponent(json["t.ssk"]);
         if(s instanceof Ed25519PublicComponent){
             this.sessionKey = s;
-        }else throw Error("Unexpected session key type");
+        }else throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: "Unexpected session key type", source: "tide-js/Models/Doken.ts:40" });
 
         var u = BaseComponent.DeserializeComponent(json["tideuserkey"]);
         if(u instanceof Ed25519PublicComponent){
             this.tideuserkey = u;
-        }else throw Error("Unexpected tide user key type");
+        }else throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: "Unexpected tide user key type", source: "tide-js/Models/Doken.ts:45" });
 
         if( typeof json.vuid === "string") this.vuid = json.vuid;
-        else throw Error("Expected vuid to be string");
+        else throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: `Expected vuid to be string (got ${typeof json.vuid})`, source: "tide-js/Models/Doken.ts:48" });
 
         if( typeof json["t.uho"] === "string") this.homeOrk = json["t.uho"];
-        else throw Error("Expected user home to be string");
+        else throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: `Expected user home to be string (got ${typeof json["t.uho"]})`, source: "tide-js/Models/Doken.ts:51" });
 
         // Will be affected by 2032 problem
         if( typeof json.exp === "number") this.exp = json.exp;
-        else throw Error("Expected exp to be a number");
+        else throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: `Expected exp to be a number (got ${typeof json.exp})`, source: "tide-js/Models/Doken.ts:55" });
 
         if( typeof json.aud === "string") this.aud = json.aud;
-        else throw Error("Expected aud to be string");
+        else throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: `Expected aud to be string (got ${typeof json.aud})`, source: "tide-js/Models/Doken.ts:58" });
 
         if( typeof json.realm_access === "object") this.realm_access = json.realm_access;
         else if(!json.realm_access) this.realm_access = null;
-        else throw Error("Expected realm_access to be string");
+        else throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: `Expected realm_access to be string (got ${typeof json.realm_access})`, source: "tide-js/Models/Doken.ts:62" });
 
         if( typeof json.resource_access === "object") this.resource_access = json.resource_access;
         else if(!json.resource_access) this.resource_access = null;
-        else throw Error("Expected resource_access to be string");
+        else throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: `Expected resource_access to be string (got ${typeof json.resource_access})`, source: "tide-js/Models/Doken.ts:66" });
     }
 
     serialize(){
@@ -89,7 +91,7 @@ export class Doken {
 
     constructor(data: string) {
         const parts = data.split(".");
-        if(parts.length != 3) throw Error("Doken must be a 3 part token (including signature)");
+        if(parts.length != 3) throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_SHAPE, displayMessage: `Doken must be a 3 part token (including signature) (got ${parts.length} parts)`, source: "tide-js/Models/Doken.ts:92" });
         this.parts = parts;
         this.dataRef = data.slice(0);
 
@@ -130,8 +132,8 @@ export class Doken {
         // When an error is thrown - its a criticial error so the whole page should stop
         // But if validation just fails, then we return false with a reason why
 
-        if(this.header.alg != "EdDSA") throw Error("Doken header alg expected to be EdDSA but got " + this.header.alg);
-        if(this.header.typ != "doken") throw Error("Doken header typ expected to be doken but got " + this.header.typ);
+        if(this.header.alg != "EdDSA") throw new TideError({ code: TideJsErrorCodes.MODEL_UNEXPECTED_HEADER, displayMessage: "Doken header alg expected to be EdDSA but got " + this.header.alg, source: "tide-js/Models/Doken.ts:133" });
+        if(this.header.typ != "doken") throw new TideError({ code: TideJsErrorCodes.MODEL_UNEXPECTED_HEADER, displayMessage: "Doken header typ expected to be doken but got " + this.header.typ, source: "tide-js/Models/Doken.ts:134" });
 
         // Check expiry
         if(Utils.CurrentTime() > this.payload.exp) return {success: false, reason: "expired"}

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -336,6 +336,75 @@ class TestInitSignRequestBuilder extends HumanReadableModelBuilder {
     }
 }
 
+class ServerCertSignRequestBuilder extends HumanReadableModelBuilder {
+    _name = "sCert";
+    _version = "1";
+    _humanReadableName = "Server Certificate";
+    get _id() { return this._name + ":" + this._version; }
+    constructor(data, reqId) {
+        super(data, reqId);
+    }
+    getDetailsMap(): any {
+        let summary: any = {};
+
+        // Extract what we can from DynamicData
+        if (this.request && this.request.dyanmicData && this.request.dyanmicData.length > 0) {
+            let resultObj: any = { result: undefined };
+            let index = 0;
+            const fields = ["realm", "clientId", "instanceId", "spiffeId"];
+            for (const field of fields) {
+                if (TryGetValue(this.request.dyanmicData, index, resultObj)) {
+                    try {
+                        summary[field] = StringFromUint8Array(resultObj.result);
+                    } catch { /* skip non-string fields */ }
+                }
+                index++;
+            }
+        }
+
+        return summary;
+    }
+    getRequestDataJson() {
+        let data: any = {};
+        if (this._draft && this._draft.length > 0) {
+            data["TBS Certificate (DER)"] = Bytes2Hex(this._draft);
+        }
+        return data;
+    }
+}
+
+class VrkEncSignRequestBuilder extends HumanReadableModelBuilder {
+    _name = "vrkEnc";
+    _version = "1";
+    _humanReadableName = "Encrypt with Vendor Rotating Key";
+    get _id() { return this._name + ":" + this._version; }
+    constructor(data, expiry) {
+        super(data, expiry);
+        if (data) {
+            let resultObj = { result: undefined };
+            let i = 0;
+            while (TryGetValue(this.request.draft, i, resultObj)) { i++; }
+            this._humanReadableName = `Encrypt ${i} piece${i != 1 ? "s" : ""} of data with VRK`;
+        }
+    }
+}
+
+class VrkDecSignRequestBuilder extends HumanReadableModelBuilder {
+    _name = "vrkDec";
+    _version = "1";
+    _humanReadableName = "Decrypt with Vendor Rotating Key";
+    get _id() { return this._name + ":" + this._version; }
+    constructor(data, expiry) {
+        super(data, expiry);
+        if (data) {
+            let resultObj = { result: undefined };
+            let i = 0;
+            while (TryGetValue(this.request.draft, i, resultObj)) { i++; }
+            this._humanReadableName = `Decrypt ${i} piece${i != 1 ? "s" : ""} of data with VRK`;
+        }
+    }
+}
+
 const modelBuildersMap = {
     [new UserContextSignRequestBuilder(null as any, null as any)._id]: UserContextSignRequestBuilder,
     [new OffboardSignRequestBuilder(null as any, null as any)._id]: OffboardSignRequestBuilder,
@@ -345,4 +414,7 @@ const modelBuildersMap = {
     [new HederaSignRequestBuilder(null as any, null as any)._id]: HederaSignRequestBuilder,
     [new PolicyEnabledEncryptionRequestBuilder(null as any, null as any)._id]: PolicyEnabledEncryptionRequestBuilder,
     [new PolicyEnabledDecryptionRequestBuilder(null as any, null as any)._id]: PolicyEnabledDecryptionRequestBuilder,
+    [new ServerCertSignRequestBuilder(null as any, null as any)._id]: ServerCertSignRequestBuilder,
+    [new VrkEncSignRequestBuilder(null as any, null as any)._id]: VrkEncSignRequestBuilder,
+    [new VrkDecSignRequestBuilder(null as any, null as any)._id]: VrkDecSignRequestBuilder,
 }

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -347,19 +347,16 @@ class ServerCertSignRequestBuilder extends HumanReadableModelBuilder {
     getDetailsMap(): any {
         let summary: any = {};
 
-        // Extract what we can from DynamicData
+        // DynamicData is JSON bytes, parse as string
         if (this.request && this.request.dyanmicData && this.request.dyanmicData.length > 0) {
-            let resultObj: any = { result: undefined };
-            let index = 0;
-            const fields = ["realm", "clientId", "instanceId", "spiffeId"];
-            for (const field of fields) {
-                if (TryGetValue(this.request.dyanmicData, index, resultObj)) {
-                    try {
-                        summary[field] = StringFromUint8Array(resultObj.result);
-                    } catch { /* skip non-string fields */ }
-                }
-                index++;
-            }
+            try {
+                const jsonStr = new TextDecoder().decode(this.request.dyanmicData);
+                const parsed = JSON.parse(jsonStr);
+                if (parsed.realm) summary["Realm"] = parsed.realm;
+                if (parsed.clientId) summary["Client ID"] = parsed.clientId;
+                if (parsed.instanceId) summary["Instance ID"] = parsed.instanceId;
+                if (parsed.spiffeId) summary["SPIFFE ID"] = parsed.spiffeId;
+            } catch { /* DynamicData not parseable as JSON */ }
         }
 
         return summary;
@@ -373,38 +370,6 @@ class ServerCertSignRequestBuilder extends HumanReadableModelBuilder {
     }
 }
 
-class VrkEncSignRequestBuilder extends HumanReadableModelBuilder {
-    _name = "vrkEnc";
-    _version = "1";
-    _humanReadableName = "Encrypt with Vendor Rotating Key";
-    get _id() { return this._name + ":" + this._version; }
-    constructor(data, expiry) {
-        super(data, expiry);
-        if (data) {
-            let resultObj = { result: undefined };
-            let i = 0;
-            while (TryGetValue(this.request.draft, i, resultObj)) { i++; }
-            this._humanReadableName = `Encrypt ${i} piece${i != 1 ? "s" : ""} of data with VRK`;
-        }
-    }
-}
-
-class VrkDecSignRequestBuilder extends HumanReadableModelBuilder {
-    _name = "vrkDec";
-    _version = "1";
-    _humanReadableName = "Decrypt with Vendor Rotating Key";
-    get _id() { return this._name + ":" + this._version; }
-    constructor(data, expiry) {
-        super(data, expiry);
-        if (data) {
-            let resultObj = { result: undefined };
-            let i = 0;
-            while (TryGetValue(this.request.draft, i, resultObj)) { i++; }
-            this._humanReadableName = `Decrypt ${i} piece${i != 1 ? "s" : ""} of data with VRK`;
-        }
-    }
-}
-
 const modelBuildersMap = {
     [new UserContextSignRequestBuilder(null as any, null as any)._id]: UserContextSignRequestBuilder,
     [new OffboardSignRequestBuilder(null as any, null as any)._id]: OffboardSignRequestBuilder,
@@ -415,6 +380,4 @@ const modelBuildersMap = {
     [new PolicyEnabledEncryptionRequestBuilder(null as any, null as any)._id]: PolicyEnabledEncryptionRequestBuilder,
     [new PolicyEnabledDecryptionRequestBuilder(null as any, null as any)._id]: PolicyEnabledDecryptionRequestBuilder,
     [new ServerCertSignRequestBuilder(null as any, null as any)._id]: ServerCertSignRequestBuilder,
-    [new VrkEncSignRequestBuilder(null as any, null as any)._id]: VrkEncSignRequestBuilder,
-    [new VrkDecSignRequestBuilder(null as any, null as any)._id]: VrkDecSignRequestBuilder,
 }

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -337,7 +337,7 @@ class TestInitSignRequestBuilder extends HumanReadableModelBuilder {
 }
 
 class ServerCertSignRequestBuilder extends HumanReadableModelBuilder {
-    _name = "sCert";
+    _name = "ServerCert";
     _version = "1";
     _humanReadableName = "Server Certificate";
     get _id() { return this._name + ":" + this._version; }

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -20,17 +20,34 @@ import BaseTideRequest from "./BaseTideRequest";
 import { Policy, ApprovalType, ExecutionType } from "./Policy";
 import { Serialization } from "../Cryptide/index";
 
+/**
+ * Optional, DISPLAY-ONLY lookup tables the caller (the admin-ui, which already
+ * holds friendly names — see keycloak-IGA formatters.humanReadableSummary) may
+ * hand to the enclave so UUID-only carriers can be rendered as readable names.
+ *
+ * SECURITY: this NEVER participates in the signed bytes. The signed
+ * AttestationUnit carries only UUIDs; these names are advisory chrome. A missing
+ * entry simply falls back to the raw UUID — never blanks, never throws, and the
+ * enclave must never trust these for any authorization decision.
+ */
+export interface HumanReadableContext {
+    /** role-id (UUID) -> role name, e.g. "tide-realm-admin". */
+    roles?: { [roleId: string]: string };
+    /** user-id (UUID) -> username, e.g. "alice". */
+    users?: { [userId: string]: string };
+}
+
 export class ModelRegistry {
-    static getHumanReadableModelBuilder(reqId: string, data: Uint8Array): HumanReadableModelBuilder {
+    static getHumanReadableModelBuilder(reqId: string, data: Uint8Array, context?: HumanReadableContext): HumanReadableModelBuilder {
         const r = BaseTideRequest.decode(data);
         const nameMatch = r.name.match(/^Custom<(.*)>$/)?.[1];
         const versionMatch = r.version.match(/^Custom<(.*)>$/)?.[1];
         if (nameMatch && versionMatch) {
-            return new CustomSignRequestBuilder(data, reqId);
+            return new CustomSignRequestBuilder(data, reqId, context);
         }
         const c = modelBuildersMap[r.id()];
         if (!c) throw Error("Could not find model: " + r.id());
-        return c.create(data, reqId);
+        return c.create(data, reqId, context);
     }
 }
 
@@ -40,16 +57,20 @@ export class HumanReadableModelBuilder {
     _draft: any;
     request: BaseTideRequest | undefined;
     reqId: any;
-    constructor(data, reqId) {
+    // DISPLAY-ONLY names map (roleId->name, userId->username). Never signed; see
+    // HumanReadableContext. Optional — undefined when the caller supplies none.
+    _context: HumanReadableContext | undefined;
+    constructor(data, reqId, context?: HumanReadableContext) {
         if (data) {
             this._data = data;
             this._draft = GetValue(this._data, 3);
             this.request = BaseTideRequest.decode(data);
         }
         this.reqId = reqId;
+        this._context = context;
     }
-    static create(data, reqId) {
-        return new this(data, reqId);
+    static create(data, reqId, context?: HumanReadableContext) {
+        return new this(data, reqId, context);
     }
     getDetailsMap() {
         // the summary
@@ -75,8 +96,8 @@ class CustomSignRequestBuilder extends HumanReadableModelBuilder {
     _version: any;
     humanReadableJson: any;
     get _id() { return this._name + ":" + this._version; }
-    constructor(data, reqId) {
-        super(data, reqId);
+    constructor(data, reqId, context?: HumanReadableContext) {
+        super(data, reqId, context);
         this._name = this.request.name.match(/^Custom<(.*)>$/)?.[1];
         this._version = this.request.version.match(/^Custom<(.*)>$/)?.[1];
         this.humanReadableJson = JSON.parse(StringFromUint8Array(GetValue(this.request.draft, 0)));
@@ -111,11 +132,11 @@ class UserContextSignRequestBuilder extends HumanReadableModelBuilder {
     _version = "1";
     get _id() { return this._name + ":" + this._version; }
 
-    constructor(data, reqId) {
-        super(data, reqId);
+    constructor(data, reqId, context?: HumanReadableContext) {
+        super(data, reqId, context);
     }
-    static create(data, reqId) {
-        return super.create(data, reqId);
+    static create(data, reqId, context?: HumanReadableContext) {
+        return super.create(data, reqId, context);
     }
     getRequestDataJson() {
         // deserialize draft here and return a pretty object for user
@@ -200,6 +221,45 @@ class PolicySignRequestBuilder extends HumanReadableModelBuilder {
     get _id() { return this._name + ":" + this._version; }
     constructor(data, expiry) {
         super(data, expiry);
+        // Make the card title context-aware. The admin-threshold re-sign
+        // (REGEN_ADMIN_POLICY) carries a Policy whose contractId is
+        // "GenericResourceAccessThresholdRole:1" and whose params scope the
+        // tide-realm-admin role on the realm-management resource (see iga-core
+        // TideAttestor.buildAdminPolicy* — POLICY_TYPE / TIDE_REALM_ADMIN_ROLE /
+        // POLICY_RESOURCE). When we can detect that exact shape from the carrier,
+        // show a specific title; otherwise keep the generic one. Display-only and
+        // fully guarded — a decode failure must never change the signed bytes nor
+        // throw out of the constructor.
+        try {
+            const policy = this._tryGetPolicy();
+            if (policy && this._isAdminThresholdPolicy(policy)) {
+                this._humanReadableName = "Update admin approval threshold (re-sign tide-realm-admin policy)";
+            }
+        } catch { /* keep the generic title */ }
+    }
+
+    // Decode the Policy carried in draft[0], or null if absent/undecodable.
+    private _tryGetPolicy(): Policy | null {
+        try {
+            if (!this._draft) return null;
+            const policyBytes = GetValue(this._draft, 0);
+            if (!policyBytes || policyBytes.length === 0) return null;
+            return Policy.from(policyBytes);
+        } catch { return null; }
+    }
+
+    // True when the Policy is the multiAdmin tide-realm-admin approval-threshold
+    // policy. Keyed on the producer-stamped contractId
+    // ("GenericResourceAccessThresholdRole:1") PLUS the role/resource params, so
+    // an ordinary GenericResourceAccessThresholdRole policy for some OTHER
+    // role/resource still falls through to the generic title.
+    private _isAdminThresholdPolicy(policy: Policy): boolean {
+        try {
+            if (policy.contractId !== "GenericResourceAccessThresholdRole:1") return false;
+            const role = policy.params?.entries?.get("role");
+            const resource = policy.params?.entries?.get("resource");
+            return role === "tide-realm-admin" && resource === "realm-management";
+        } catch { return false; }
     }
 
     getDetailsMap(): any {
@@ -210,6 +270,18 @@ class PolicySignRequestBuilder extends HumanReadableModelBuilder {
 
         const policyBytes = GetValue(draftBytes, 0);
         const policy = Policy.from(policyBytes);
+
+        // For the admin-threshold re-sign, surface the new threshold up front
+        // (the only human-meaningful change in the policy). The Policy carries
+        // the NEW threshold in its params; the OLD value is NOT in the signed
+        // carrier (it lives in the CR ROWS_JSON, which the enclave never sees),
+        // so we show only what the carrier actually proves.
+        if (this._isAdminThresholdPolicy(policy)) {
+            const threshold = policy.params?.entries?.get("threshold");
+            if (threshold !== undefined && !(threshold instanceof Uint8Array)) {
+                summary["New admin approvals required"] = threshold;
+            }
+        }
 
         summary['Version'] = policy.version;
         summary['ContractId'] = policy.contractId;
@@ -505,8 +577,30 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
     _version = "1";
     _humanReadableName = "Approve Attestation — Role Assignment";
     get _id() { return this._name + ":" + this._version; }
-    constructor(data, reqId) {
-        super(data, reqId);
+    constructor(data, reqId, context?: HumanReadableContext) {
+        super(data, reqId, context);
+    }
+
+    // Resolve a role-id UUID to its friendly name via the display-only context,
+    // falling back to the raw UUID when no name is available. Never throws.
+    private _roleName(roleId: any): string {
+        const id = String(roleId);
+        try {
+            const name = this._context?.roles?.[id];
+            if (typeof name === "string" && name.length > 0) return name;
+        } catch { /* fall through to id */ }
+        return id;
+    }
+
+    // Resolve a user-id UUID to its username via the display-only context,
+    // falling back to the raw UUID when no name is available. Never throws.
+    private _userName(userId: any): string {
+        const id = String(userId);
+        try {
+            const name = this._context?.users?.[id];
+            if (typeof name === "string" && name.length > 0) return name;
+        } catch { /* fall through to id */ }
+        return id;
     }
 
     // Decode every attestation-unit envelope the draft carries. The draft is
@@ -564,10 +658,14 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
 
                 const payload = first["payload"];
                 if (payload && typeof payload === "object") {
-                    if (payload["user_id"] !== undefined) summary["Target User"] = String(payload["user_id"]);
+                    // Map UUIDs -> friendly names from the display-only context
+                    // when available; fall back to the raw UUID otherwise so the
+                    // admin can read "grant tide-realm-admin to alice" instead of
+                    // two opaque UUIDs. The signed bytes still carry only UUIDs.
+                    if (payload["user_id"] !== undefined) summary["Target User"] = this._userName(payload["user_id"]);
                     const roleIds = payload["role_ids"];
                     if (Array.isArray(roleIds) && roleIds.length > 0) {
-                        summary["Roles"] = roleIds.map((r: any) => String(r)).join(", ");
+                        summary["Roles"] = roleIds.map((r: any) => this._roleName(r)).join(", ");
                     }
                 }
                 if (first["target_id"] !== undefined && summary["Target User"] === undefined) {

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -22,12 +22,12 @@ import { Serialization } from "../Cryptide/index";
 
 /**
  * Optional, DISPLAY-ONLY lookup tables the caller (the admin-ui, which already
- * holds friendly names — see keycloak-IGA formatters.humanReadableSummary) may
+ * holds friendly names - see keycloak-IGA formatters.humanReadableSummary) may
  * hand to the enclave so UUID-only carriers can be rendered as readable names.
  *
  * SECURITY: this NEVER participates in the signed bytes. The signed
  * AttestationUnit carries only UUIDs; these names are advisory chrome. A missing
- * entry simply falls back to the raw UUID — never blanks, never throws, and the
+ * entry simply falls back to the raw UUID - never blanks, never throws, and the
  * enclave must never trust these for any authorization decision.
  */
 export interface HumanReadableContext {
@@ -58,7 +58,7 @@ export class HumanReadableModelBuilder {
     request: BaseTideRequest | undefined;
     reqId: any;
     // DISPLAY-ONLY names map (roleId->name, userId->username). Never signed; see
-    // HumanReadableContext. Optional — undefined when the caller supplies none.
+    // HumanReadableContext. Optional - undefined when the caller supplies none.
     _context: HumanReadableContext | undefined;
     constructor(data, reqId, context?: HumanReadableContext) {
         if (data) {
@@ -225,10 +225,10 @@ class PolicySignRequestBuilder extends HumanReadableModelBuilder {
         // (REGEN_ADMIN_POLICY) carries a Policy whose contractId is
         // "GenericResourceAccessThresholdRole:1" and whose params scope the
         // tide-realm-admin role on the realm-management resource (see iga-core
-        // TideAttestor.buildAdminPolicy* — POLICY_TYPE / TIDE_REALM_ADMIN_ROLE /
+        // TideAttestor.buildAdminPolicy* - POLICY_TYPE / TIDE_REALM_ADMIN_ROLE /
         // POLICY_RESOURCE). When we can detect that exact shape from the carrier,
         // show a specific title; otherwise keep the generic one. Display-only and
-        // fully guarded — a decode failure must never change the signed bytes nor
+        // fully guarded - a decode failure must never change the signed bytes nor
         // throw out of the constructor.
         try {
             const policy = this._tryGetPolicy();
@@ -298,7 +298,7 @@ class PolicySignRequestBuilder extends HumanReadableModelBuilder {
         // an EMPTY (0-byte) placeholder whose only purpose is to position draft[2]
         // (the ORK's revoke-authorizing-policy flag). Only parse it as a contract
         // when it actually carries a length-prefixed structure (>= 4 bytes for a
-        // TideMemory header) — an empty segment must be skipped, not read.
+        // TideMemory header) - an empty segment must be skipped, not read.
         let res: any = {};
         if (TryGetValue(draftBytes, 1, res) && res.result && res.result.length >= 4) {
             const contractBytes = res.result;
@@ -453,10 +453,10 @@ class ServerCertSignRequestBuilder extends HumanReadableModelBuilder {
 //
 // The AttestationUnit:1 draft carries one or more attestation-unit envelopes as
 // VERBATIM CBOR (produced by Jackson's default CBOR mapper on the iga-core
-// producer side — see RealmAttestationExporter / AttestationUnit.java). tide-js
+// producer side - see RealmAttestationExporter / AttestationUnit.java). tide-js
 // has no CBOR dependency, so we decode the small, well-defined subset Jackson
 // emits here: unsigned/negative integers, byte/text strings, arrays, maps and
-// the simple values false/true/null — definite AND indefinite length. This is
+// the simple values false/true/null - definite AND indefinite length. This is
 // display-only (the enclave renders the result); it never participates in the
 // signed bytes, so a decode failure must degrade gracefully, never throw.
 function decodeCbor(bytes: Uint8Array): any {
@@ -535,7 +535,7 @@ function decodeCbor(bytes: Uint8Array): any {
                 if (ai === 22) return null;      // null
                 if (ai === 23) return undefined; // undefined
                 if (ai === 25 || ai === 26 || ai === 27) {
-                    // half/single/double float — not used by the unit envelopes; skip bytes.
+                    // half/single/double float - not used by the unit envelopes; skip bytes.
                     readUint(ai === 25 ? 2 : ai === 26 ? 4 : 8);
                     return null;
                 }
@@ -581,13 +581,13 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
     // lacked this builder and fell through to the carrier short-name). The
     // constructor refines this to a specific, context-aware title below, but
     // even if decoding fails the admin still sees an intelligible role-assignment
-    // summary — never "AE", never the bare model id.
-    _humanReadableName = "Grant role(s) — Role Assignment";
+    // summary - never "AE", never the bare model id.
+    _humanReadableName = "Grant role(s) - Role Assignment";
     get _id() { return this._name + ":" + this._version; }
     constructor(data, reqId, context?: HumanReadableContext) {
         super(data, reqId, context);
         // Refine the card title from the actual carried unit. Display-only and
-        // fully guarded — a decode failure must never throw out of the
+        // fully guarded - a decode failure must never throw out of the
         // constructor nor change the signed bytes; it just keeps the generic
         // (still human-readable) title above.
         try {
@@ -623,17 +623,17 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
             if (roleNames && userName) return `Grant role ${roleNames} to ${userName}`;
             if (roleNames) return `Grant role ${roleNames}`;
             if (userName) return `Update roles for ${userName}`;
-            return "Grant role(s) — Role Assignment";
+            return "Grant role(s) - Role Assignment";
         }
 
         // Any other attestation unit: still give a readable, type-specific title
         // instead of the opaque carrier code.
-        if (utName) return `Approve change — ${utName.replace(/_/g, " ")}`;
+        if (utName) return `Approve change - ${utName.replace(/_/g, " ")}`;
         return undefined;
     }
 
     // Role names for the title ONLY when the context supplied at least one
-    // friendly name — we don't want a title full of UUIDs, so if no name
+    // friendly name - we don't want a title full of UUIDs, so if no name
     // resolved we return undefined and let the caller use generic phrasing.
     private _titleRoleNames(payload: any): string | undefined {
         try {
@@ -685,7 +685,7 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
     // Decode every attestation-unit envelope the draft carries. The draft is
     // AttestationUnitSignRequest framing: a TideMemory whose segment i is the
     // verbatim CBOR of unit i (req.SetUnits(byte[][]) on the producer). Never
-    // throws — a malformed/absent unit is simply skipped.
+    // throws - a malformed/absent unit is simply skipped.
     private _decodeUnits(): any[] {
         const units: any[] = [];
         if (!this._draft) return units;
@@ -700,7 +700,7 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
 
     // Decode the embedded admin Policy from the request's policy segment
     // (seg-9, req.SetPolicy(adminPolicyBytes)). Returns null when absent or
-    // undecodable — never throws.
+    // undecodable - never throws.
     private _decodePolicy(): Policy | null {
         try {
             const policyBytes = this.request?.policy;

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -19,6 +19,8 @@ import { AuthorizerPack, Bytes2Hex, GetValue, StringFromUint8Array, TryGetValue 
 import BaseTideRequest from "./BaseTideRequest";
 import { Policy, ApprovalType, ExecutionType } from "./Policy";
 import { Serialization } from "../Cryptide/index";
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
 
 export class ModelRegistry {
     static getHumanReadableModelBuilder(reqId: string, data: Uint8Array): HumanReadableModelBuilder {
@@ -29,7 +31,7 @@ export class ModelRegistry {
             return new CustomSignRequestBuilder(data, reqId);
         }
         const c = modelBuildersMap[r.id()];
-        if (!c) throw Error("Could not find model: " + r.id());
+        if (!c) throw new TideError({ code: TideJsErrorCodes.MODEL_UNKNOWN_MODEL, displayMessage: `Could not find model: ${r.id()}`, source: "tide-js/Models/ModelRegistry.ts:34" });
         return c.create(data, reqId);
     }
 }

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -575,14 +575,19 @@ const ATTESTATION_UNIT_TYPE_NAMES: { [k: number]: string } = {
 class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
     _name = "AttestationUnit";
     _version = "1";
-    // GENERIC, always-human-readable fallback. The enclave renderer uses
-    // `_humanReadableName ?? _name` for the card TITLE, so this MUST never be a
-    // raw/opaque code (the old "AE" short code came from a stale bundle that
-    // lacked this builder and fell through to the carrier short-name). The
-    // constructor refines this to a specific, context-aware title below, but
-    // even if decoding fails the admin still sees an intelligible role-assignment
-    // summary - never "AE", never the bare model id.
-    _humanReadableName = "Grant role(s) - Role Assignment";
+    // GENERIC, always-human-readable, ACTION-NEUTRAL fallback. The enclave
+    // renderer uses `_humanReadableName ?? _name` for the card TITLE, so this MUST
+    // never be a raw/opaque code (the old "AE" short code came from a stale bundle
+    // that lacked this builder and fell through to the carrier short-name).
+    //
+    // It must ALSO never assert an action verb (grant/delete/create/update/revoke):
+    // the signed draft carries only the structural `unit_type` + payloads, NOT the
+    // CR action verb, so we cannot prove what is happening to the artifact from the
+    // bytes. A DELETE_CLIENT / OFFBOARD_REALM / etc. must NEVER render as "grant a
+    // role". The constructor refines this to a type-specific (still neutral) title
+    // below; even if decoding fails the admin sees an honest "Governance change"
+    // rather than a fabricated grant.
+    _humanReadableName = "Governance change";
     get _id() { return this._name + ":" + this._version; }
     constructor(data, reqId, context?: HumanReadableContext) {
         super(data, reqId, context);
@@ -592,13 +597,22 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
         // (still human-readable) title above.
         try {
             this._humanReadableName = this._buildTitle() ?? this._humanReadableName;
-        } catch { /* keep the generic role-assignment title */ }
+        } catch { /* keep the neutral "Governance change" title */ }
     }
 
     // Compute a specific, human-readable card title for the carried unit, using
     // the display-only HumanReadableContext (role/user names) when present.
-    // Returns undefined when no unit can be decoded, so the caller keeps the
-    // generic fallback. NEVER returns the raw "AE"/model code.
+    //
+    // HONESTY CONTRACT: the signed draft carries only the structural `unit_type`
+    // (realm_config, client_config, ... user_role_mapping_set) + payloads. It does
+    // NOT carry the CR action verb (grant/delete/create/update/revoke), so we
+    // CANNOT prove delete-vs-edit-vs-create from the bytes. This method therefore
+    // NEVER asserts an action verb. It describes the artifact TYPE honestly
+    // ("Approve change - client config") and, for role-assignment, uses neutral
+    // "Role assignment update" wording (the unit is a declarative set carrying
+    // both grants AND revokes - see comment below). Returns undefined only when no
+    // unit can be decoded, so the caller keeps the neutral "Governance change"
+    // fallback. There is NO code path here that yields a "Grant ..." title.
     private _buildTitle(): string | undefined {
         const units = this._decodeUnits();
         const first = units[0];
@@ -611,43 +625,21 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
 
         if (utName === "user_role_mapping_set") {
             // user_role_mapping_set is a DECLARATIVE set (the user's full desired
-            // role_ids), so the same unit type carries both grants and revokes.
-            // We frame it as a role assignment and, when names are supplied via
-            // the context, surface "Grant role <names> to <user>". When names
-            // aren't wired through yet (admin-ui -> heimdall -> ork follow-up),
-            // we fall back to the role-assignment phrasing rather than dumping
-            // raw UUIDs into the title.
+            // role_ids), so the same unit type carries both grants AND revokes. We
+            // CANNOT tell which from the bytes, so we must NOT say "Grant". Use
+            // neutral "Role assignment update" wording, naming the target user when
+            // the display-only context resolves it; the resulting role set is shown
+            // in the details map, not asserted as a grant in the title.
             const payload = first["payload"];
-            const roleNames = this._titleRoleNames(payload);
             const userName = this._titleUserName(payload);
-            if (roleNames && userName) return `Grant role ${roleNames} to ${userName}`;
-            if (roleNames) return `Grant role ${roleNames}`;
-            if (userName) return `Update roles for ${userName}`;
-            return "Grant role(s) - Role Assignment";
+            if (userName) return `Role assignment update for ${userName}`;
+            return "Role assignment update";
         }
 
-        // Any other attestation unit: still give a readable, type-specific title
-        // instead of the opaque carrier code.
+        // Any other attestation unit: give a readable, type-specific title that is
+        // honest about the artifact type without asserting an action verb.
         if (utName) return `Approve change - ${utName.replace(/_/g, " ")}`;
         return undefined;
-    }
-
-    // Role names for the title ONLY when the context supplied at least one
-    // friendly name - we don't want a title full of UUIDs, so if no name
-    // resolved we return undefined and let the caller use generic phrasing.
-    private _titleRoleNames(payload: any): string | undefined {
-        try {
-            const roleIds = payload?.["role_ids"];
-            if (!Array.isArray(roleIds) || roleIds.length === 0) return undefined;
-            const named: string[] = [];
-            let anyNamed = false;
-            for (const r of roleIds) {
-                const id = String(r);
-                const name = this._context?.roles?.[id];
-                if (typeof name === "string" && name.length > 0) { named.push(name); anyNamed = true; }
-            }
-            return anyNamed ? named.join(", ") : undefined;
-        } catch { return undefined; }
     }
 
     // User name for the title ONLY when the context resolved it to a username.
@@ -733,14 +725,20 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
                     ? ATTESTATION_UNIT_TYPE_NAMES[ut]
                     : (ut !== undefined ? String(ut) : undefined);
                 if (utName !== undefined) summary["Attestation Unit"] = utName;
-                if (utName === "user_role_mapping_set") summary["Action"] = "Grant role(s) to user";
 
                 const payload = first["payload"];
                 if (payload && typeof payload === "object") {
                     // Map UUIDs -> friendly names from the display-only context
                     // when available; fall back to the raw UUID otherwise so the
-                    // admin can read "grant tide-realm-admin to alice" instead of
-                    // two opaque UUIDs. The signed bytes still carry only UUIDs.
+                    // admin reads "tide-realm-admin / alice" instead of two opaque
+                    // UUIDs. The signed bytes still carry only UUIDs.
+                    //
+                    // NOTE: we surface the TARGET and the RESULTING role set under
+                    // neutral keys ("Target User", "Roles"). We do NOT assert an
+                    // action ("Grant role(s) to user"): the draft carries no action
+                    // verb, and user_role_mapping_set is a declarative set that may
+                    // be granting OR revoking. Showing the resulting set without a
+                    // verb is the honest, provable rendering.
                     if (payload["user_id"] !== undefined) summary["Target User"] = this._userName(payload["user_id"]);
                     const roleIds = payload["role_ids"];
                     if (Array.isArray(roleIds) && roleIds.length > 0) {

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -370,6 +370,276 @@ class ServerCertSignRequestBuilder extends HumanReadableModelBuilder {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Minimal, dependency-free CBOR decoder.
+//
+// The AttestationUnit:1 draft carries one or more attestation-unit envelopes as
+// VERBATIM CBOR (produced by Jackson's default CBOR mapper on the iga-core
+// producer side — see RealmAttestationExporter / AttestationUnit.java). tide-js
+// has no CBOR dependency, so we decode the small, well-defined subset Jackson
+// emits here: unsigned/negative integers, byte/text strings, arrays, maps and
+// the simple values false/true/null — definite AND indefinite length. This is
+// display-only (the enclave renders the result); it never participates in the
+// signed bytes, so a decode failure must degrade gracefully, never throw.
+function decodeCbor(bytes: Uint8Array): any {
+    const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    let pos = 0;
+
+    function readUint(n: number): number {
+        let v = 0;
+        for (let i = 0; i < n; i++) { v = v * 256 + dv.getUint8(pos); pos++; }
+        return v;
+    }
+
+    function readLength(ai: number): number {
+        if (ai < 24) return ai;
+        if (ai === 24) return readUint(1);
+        if (ai === 25) return readUint(2);
+        if (ai === 26) return readUint(4);
+        if (ai === 27) return readUint(8); // may lose precision beyond 2^53; fine for display
+        if (ai === 31) return -1;          // indefinite length
+        throw new Error("Unsupported CBOR additional info: " + ai);
+    }
+
+    function readItem(): any {
+        const ib = dv.getUint8(pos); pos++;
+        const major = ib >> 5;
+        const ai = ib & 0x1f;
+
+        switch (major) {
+            case 0: // unsigned int
+                return readLength(ai);
+            case 1: // negative int
+                return -1 - readLength(ai);
+            case 2: { // byte string
+                if (ai === 31) { // indefinite chunks
+                    const chunks: number[] = [];
+                    while (dv.getUint8(pos) !== 0xff) { const c = readItem(); for (const b of c) chunks.push(b); }
+                    pos++; // consume break
+                    return new Uint8Array(chunks);
+                }
+                const len = readLength(ai);
+                const out = bytes.subarray(pos, pos + len); pos += len;
+                return new Uint8Array(out);
+            }
+            case 3: { // text string
+                if (ai === 31) {
+                    let s = "";
+                    while (dv.getUint8(pos) !== 0xff) { s += readItem(); }
+                    pos++;
+                    return s;
+                }
+                const len = readLength(ai);
+                const slice = bytes.subarray(pos, pos + len); pos += len;
+                return new TextDecoder().decode(slice);
+            }
+            case 4: { // array
+                const arr: any[] = [];
+                if (ai === 31) { while (dv.getUint8(pos) !== 0xff) arr.push(readItem()); pos++; return arr; }
+                const len = readLength(ai);
+                for (let i = 0; i < len; i++) arr.push(readItem());
+                return arr;
+            }
+            case 5: { // map
+                const map: any = {};
+                if (ai === 31) {
+                    while (dv.getUint8(pos) !== 0xff) { const k = readItem(); map[String(k)] = readItem(); }
+                    pos++;
+                    return map;
+                }
+                const len = readLength(ai);
+                for (let i = 0; i < len; i++) { const k = readItem(); map[String(k)] = readItem(); }
+                return map;
+            }
+            case 7: // simple / float
+                if (ai === 20) return false;
+                if (ai === 21) return true;
+                if (ai === 22) return null;      // null
+                if (ai === 23) return undefined; // undefined
+                if (ai === 25 || ai === 26 || ai === 27) {
+                    // half/single/double float — not used by the unit envelopes; skip bytes.
+                    readUint(ai === 25 ? 2 : ai === 26 ? 4 : 8);
+                    return null;
+                }
+                return null;
+            default:
+                throw new Error("Unsupported CBOR major type: " + major);
+        }
+    }
+
+    return readItem();
+}
+
+// Maps the integer unit_type ordinal (AttestationUnitType.wireValue, the
+// authoritative producer→ork mapping) back to the snake_case wire name for
+// display. Kept in lock-step with iga-core AttestationUnitType.java.
+const ATTESTATION_UNIT_TYPE_NAMES: { [k: number]: string } = {
+    0: "realm_config",
+    1: "client_config",
+    2: "client_scope_config",
+    3: "protocol_mapper",
+    4: "role_definition",
+    5: "group_definition",
+    6: "user_identity",
+    7: "user_role_mapping_set",
+    8: "user_group_membership_set",
+    9: "group_role_mapping_set",
+    10: "role_composite_children_set",
+    11: "client_scope_assignment_set",
+    12: "client_mapper_set",
+    13: "client_scope_mapper_set",
+    14: "scope_role_allowlist_set",
+    15: "realm_default_groups_set",
+    16: "organization_definition",
+    17: "organization_domain_set",
+};
+
+class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
+    _name = "AttestationUnit";
+    _version = "1";
+    _humanReadableName = "Approve Attestation — Role Assignment";
+    get _id() { return this._name + ":" + this._version; }
+    constructor(data, reqId) {
+        super(data, reqId);
+    }
+
+    // Decode every attestation-unit envelope the draft carries. The draft is
+    // AttestationUnitSignRequest framing: a TideMemory whose segment i is the
+    // verbatim CBOR of unit i (req.SetUnits(byte[][]) on the producer). Never
+    // throws — a malformed/absent unit is simply skipped.
+    private _decodeUnits(): any[] {
+        const units: any[] = [];
+        if (!this._draft) return units;
+        let res: any = {};
+        for (let i = 0; TryGetValue(this._draft, i, res); i++) {
+            const unitBytes = res.result;
+            if (!unitBytes || unitBytes.length === 0) continue;
+            try { units.push(decodeCbor(unitBytes)); } catch { /* skip undecodable unit */ }
+        }
+        return units;
+    }
+
+    // Decode the embedded admin Policy from the request's policy segment
+    // (seg-9, req.SetPolicy(adminPolicyBytes)). Returns null when absent or
+    // undecodable — never throws.
+    private _decodePolicy(): Policy | null {
+        try {
+            const policyBytes = this.request?.policy;
+            if (!policyBytes || policyBytes.length === 0) return null;
+            return Policy.from(policyBytes);
+        } catch { return null; }
+    }
+
+    // Pull a parameter from the Policy params map, tolerating missing keys.
+    private _policyParam(policy: Policy | null, key: string): any {
+        try {
+            if (!policy || !policy.params) return undefined;
+            const v = policy.params.entries.get(key);
+            if (v instanceof Uint8Array) return undefined; // don't surface raw bytes
+            return v;
+        } catch { return undefined; }
+    }
+
+    getDetailsMap(): any {
+        const summary: any = {};
+        try {
+            const units = this._decodeUnits();
+            const policy = this._decodePolicy();
+
+            // ---- the action / unit being attested ------------------------------
+            const first = units[0];
+            if (first && typeof first === "object") {
+                const ut = first["unit_type"];
+                const utName = (typeof ut === "number" && ATTESTATION_UNIT_TYPE_NAMES[ut] !== undefined)
+                    ? ATTESTATION_UNIT_TYPE_NAMES[ut]
+                    : (ut !== undefined ? String(ut) : undefined);
+                if (utName !== undefined) summary["Attestation Unit"] = utName;
+                if (utName === "user_role_mapping_set") summary["Action"] = "Grant role(s) to user";
+
+                const payload = first["payload"];
+                if (payload && typeof payload === "object") {
+                    if (payload["user_id"] !== undefined) summary["Target User"] = String(payload["user_id"]);
+                    const roleIds = payload["role_ids"];
+                    if (Array.isArray(roleIds) && roleIds.length > 0) {
+                        summary["Roles"] = roleIds.map((r: any) => String(r)).join(", ");
+                    }
+                }
+                if (first["target_id"] !== undefined && summary["Target User"] === undefined) {
+                    summary["Target"] = String(first["target_id"]);
+                }
+            }
+            if (units.length > 1) summary["Units In Request"] = units.length;
+
+            // ---- the governing admin Policy ------------------------------------
+            if (policy) {
+                const role = this._policyParam(policy, "role");
+                if (role !== undefined) summary["Governing Policy Role"] = String(role);
+                const resource = this._policyParam(policy, "resource");
+                if (resource !== undefined) summary["Resource"] = String(resource);
+                const threshold = this._policyParam(policy, "threshold");
+                if (threshold !== undefined) summary["Approvals Required"] = threshold;
+            }
+
+            // ---- timing (also surfaced by the enclave chrome; included here for
+            //      a self-contained card, guarded so it never throws) ------------
+            try {
+                if (this.request && typeof this.request.expiry === "number") {
+                    summary["Expires"] = new Date(this.request.expiry * 1000).toUTCString();
+                }
+            } catch { /* expiry not readable */ }
+            try {
+                if (this.request && this.request.isInitialized()) {
+                    summary["Requested At"] = new Date(this.request.getInitializedTime() * 1000).toUTCString();
+                }
+            } catch { /* not initialized */ }
+        } catch { /* never throw from the summary builder */ }
+        return summary;
+    }
+
+    getRequestDataJson(): any {
+        const data: any = {};
+        try {
+            const units = this._decodeUnits();
+            // Render bytes as hex so the JSON view is clean (decodeCbor only yields
+            // Uint8Array for CBOR byte-strings, which the unit payloads don't use,
+            // but guard anyway).
+            data["units"] = units.map((u) => this._jsonSafe(u));
+
+            const policy = this._decodePolicy();
+            if (policy) {
+                const role = this._policyParam(policy, "role");
+                const resource = this._policyParam(policy, "resource");
+                const threshold = this._policyParam(policy, "threshold");
+                const p: any = {};
+                if (role !== undefined) p.role = role;
+                if (resource !== undefined) p.resource = resource;
+                if (threshold !== undefined) p.threshold = threshold;
+                data["policy"] = p;
+            }
+        } catch { /* never throw */ }
+        return data;
+    }
+
+    // Recursively replace Uint8Array with hex strings so JSON.stringify in the
+    // enclave produces a readable view.
+    private _jsonSafe(v: any): any {
+        if (v instanceof Uint8Array) return Bytes2Hex(v);
+        if (Array.isArray(v)) return v.map((x) => this._jsonSafe(x));
+        if (v && typeof v === "object") {
+            const out: any = {};
+            for (const k of Object.keys(v)) out[k] = this._jsonSafe(v[k]);
+            return out;
+        }
+        return v;
+    }
+
+    // NOTE: getDataToApprove() is intentionally NOT overridden. The enclave signs
+    // exactly what the base HumanReadableModelBuilder returns (this.request
+    // .dataToApprove()), identical to PolicySignRequestBuilder and every other
+    // approval builder, so SessionKey.sign(getDataToApprove()) + addApproval
+    // produce a valid approval.
+}
+
 const modelBuildersMap = {
     [new UserContextSignRequestBuilder(null as any, null as any)._id]: UserContextSignRequestBuilder,
     [new OffboardSignRequestBuilder(null as any, null as any)._id]: OffboardSignRequestBuilder,
@@ -380,4 +650,5 @@ const modelBuildersMap = {
     [new PolicyEnabledEncryptionRequestBuilder(null as any, null as any)._id]: PolicyEnabledEncryptionRequestBuilder,
     [new PolicyEnabledDecryptionRequestBuilder(null as any, null as any)._id]: PolicyEnabledDecryptionRequestBuilder,
     [new ServerCertSignRequestBuilder(null as any, null as any)._id]: ServerCertSignRequestBuilder,
+    [new AttestationUnitSignRequestBuilder(null as any, null as any)._id]: AttestationUnitSignRequestBuilder,
 }

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -221,8 +221,14 @@ class PolicySignRequestBuilder extends HumanReadableModelBuilder {
             if (!(value instanceof Uint8Array)) summary[`Parameter:${key}`] = value;
         }
 
+        // draft[1] is OPTIONAL. For a contract-upload policy it holds the
+        // contractTransport structure; for an admin-threshold policy re-sign it is
+        // an EMPTY (0-byte) placeholder whose only purpose is to position draft[2]
+        // (the ORK's revoke-authorizing-policy flag). Only parse it as a contract
+        // when it actually carries a length-prefixed structure (>= 4 bytes for a
+        // TideMemory header) — an empty segment must be skipped, not read.
         let res: any = {};
-        if (TryGetValue(draftBytes, 1, res)) {
+        if (TryGetValue(draftBytes, 1, res) && res.result && res.result.length >= 4) {
             const contractBytes = res.result;
             const contractType = StringFromUint8Array(GetValue(contractBytes, 0));
             summary["Contract To Upload Type"] = contractType;
@@ -242,7 +248,7 @@ class PolicySignRequestBuilder extends HumanReadableModelBuilder {
         // forsetiData = [placeholder, innerPayload]
         // innerPayload = [sourceCode, entryType?]
         let res: any = {};
-        if (TryGetValue(draftBytes, 1, res)) {
+        if (TryGetValue(draftBytes, 1, res) && res.result && res.result.length >= 4) {
             const contractBytes = res.result;
 
             // contractBytes[1] = forsetiData

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -575,10 +575,89 @@ const ATTESTATION_UNIT_TYPE_NAMES: { [k: number]: string } = {
 class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
     _name = "AttestationUnit";
     _version = "1";
-    _humanReadableName = "Approve Attestation — Role Assignment";
+    // GENERIC, always-human-readable fallback. The enclave renderer uses
+    // `_humanReadableName ?? _name` for the card TITLE, so this MUST never be a
+    // raw/opaque code (the old "AE" short code came from a stale bundle that
+    // lacked this builder and fell through to the carrier short-name). The
+    // constructor refines this to a specific, context-aware title below, but
+    // even if decoding fails the admin still sees an intelligible role-assignment
+    // summary — never "AE", never the bare model id.
+    _humanReadableName = "Grant role(s) — Role Assignment";
     get _id() { return this._name + ":" + this._version; }
     constructor(data, reqId, context?: HumanReadableContext) {
         super(data, reqId, context);
+        // Refine the card title from the actual carried unit. Display-only and
+        // fully guarded — a decode failure must never throw out of the
+        // constructor nor change the signed bytes; it just keeps the generic
+        // (still human-readable) title above.
+        try {
+            this._humanReadableName = this._buildTitle() ?? this._humanReadableName;
+        } catch { /* keep the generic role-assignment title */ }
+    }
+
+    // Compute a specific, human-readable card title for the carried unit, using
+    // the display-only HumanReadableContext (role/user names) when present.
+    // Returns undefined when no unit can be decoded, so the caller keeps the
+    // generic fallback. NEVER returns the raw "AE"/model code.
+    private _buildTitle(): string | undefined {
+        const units = this._decodeUnits();
+        const first = units[0];
+        if (!first || typeof first !== "object") return undefined;
+
+        const ut = first["unit_type"];
+        const utName = (typeof ut === "number" && ATTESTATION_UNIT_TYPE_NAMES[ut] !== undefined)
+            ? ATTESTATION_UNIT_TYPE_NAMES[ut]
+            : (ut !== undefined ? String(ut) : undefined);
+
+        if (utName === "user_role_mapping_set") {
+            // user_role_mapping_set is a DECLARATIVE set (the user's full desired
+            // role_ids), so the same unit type carries both grants and revokes.
+            // We frame it as a role assignment and, when names are supplied via
+            // the context, surface "Grant role <names> to <user>". When names
+            // aren't wired through yet (admin-ui -> heimdall -> ork follow-up),
+            // we fall back to the role-assignment phrasing rather than dumping
+            // raw UUIDs into the title.
+            const payload = first["payload"];
+            const roleNames = this._titleRoleNames(payload);
+            const userName = this._titleUserName(payload);
+            if (roleNames && userName) return `Grant role ${roleNames} to ${userName}`;
+            if (roleNames) return `Grant role ${roleNames}`;
+            if (userName) return `Update roles for ${userName}`;
+            return "Grant role(s) — Role Assignment";
+        }
+
+        // Any other attestation unit: still give a readable, type-specific title
+        // instead of the opaque carrier code.
+        if (utName) return `Approve change — ${utName.replace(/_/g, " ")}`;
+        return undefined;
+    }
+
+    // Role names for the title ONLY when the context supplied at least one
+    // friendly name — we don't want a title full of UUIDs, so if no name
+    // resolved we return undefined and let the caller use generic phrasing.
+    private _titleRoleNames(payload: any): string | undefined {
+        try {
+            const roleIds = payload?.["role_ids"];
+            if (!Array.isArray(roleIds) || roleIds.length === 0) return undefined;
+            const named: string[] = [];
+            let anyNamed = false;
+            for (const r of roleIds) {
+                const id = String(r);
+                const name = this._context?.roles?.[id];
+                if (typeof name === "string" && name.length > 0) { named.push(name); anyNamed = true; }
+            }
+            return anyNamed ? named.join(", ") : undefined;
+        } catch { return undefined; }
+    }
+
+    // User name for the title ONLY when the context resolved it to a username.
+    private _titleUserName(payload: any): string | undefined {
+        try {
+            const userId = payload?.["user_id"];
+            if (userId === undefined) return undefined;
+            const name = this._context?.users?.[String(userId)];
+            return (typeof name === "string" && name.length > 0) ? name : undefined;
+        } catch { return undefined; }
     }
 
     // Resolve a role-id UUID to its friendly name via the display-only context,

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -126,65 +126,6 @@ class HederaSignRequestBuilder extends HumanReadableModelBuilder {
         return this.additionalInfo;
     }
 }
-class UserContextSignRequestBuilder extends HumanReadableModelBuilder {
-    _name = "UserContext"; // Model ID
-    _humanReadableName = "User Access Change";
-    _version = "1";
-    get _id() { return this._name + ":" + this._version; }
-
-    constructor(data, reqId, context?: HumanReadableContext) {
-        super(data, reqId, context);
-    }
-    static create(data, reqId, context?: HumanReadableContext) {
-        return super.create(data, reqId, context);
-    }
-    getRequestDataJson() {
-        // deserialize draft here and return a pretty object for user
-        let prettyObject: any = {};
-
-        let draftIndex = 0;
-        // make sure user context is JSON
-        let cont = true;
-        prettyObject.UserContexts = [];
-        while (cont) {
-            try { prettyObject.UserContexts.push(JSON.parse(StringFromUint8Array(GetValue(this._draft, draftIndex)))); draftIndex++; }
-            catch { cont = false; }
-        }
-
-        // return a nice object of InitCert? and usercontexts
-        return prettyObject;
-    }
-    getDetailsMap(): any {
-        // deserialize draft here and return a pretty object for user
-        let prettyObject: any = {};
-
-        let draftIndex = 0;
-        // make sure user context is JSON
-        let cont = true;
-        prettyObject.UserContexts = [];
-        while (cont) {
-            try { prettyObject.UserContexts.push(JSON.parse(StringFromUint8Array(GetValue(this._draft, draftIndex)))); draftIndex++; }
-            catch { cont = false; }
-        }
-
-        // Create summary
-        let summary: any = {};
-        // Get the clients involved in this approval
-        // All clients will be either realm-management or under resource_management
-        let clients = [];
-        prettyObject.UserContexts.map(c => {
-            if (c.realm_access) clients.push("realm_access");
-            if (typeof c.resource_access === "object") {
-                clients.push(...Object.keys(c.resource_access));
-            }
-        })
-        clients = [...new Set(clients)];
-        summary["Applications affected"] = clients.join(", ");
-
-        // return a nice object of InitCert? and usercontexts
-        return summary;
-    }
-}
 
 export class OffboardSignRequestBuilder extends HumanReadableModelBuilder {
     _name = "Offboard";
@@ -1219,7 +1160,6 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
 }
 
 const modelBuildersMap = {
-    [new UserContextSignRequestBuilder(null as any, null as any)._id]: UserContextSignRequestBuilder,
     [new OffboardSignRequestBuilder(null as any, null as any)._id]: OffboardSignRequestBuilder,
     [new LicenseSignRequestBuilder(null as any, null as any)._id]: LicenseSignRequestBuilder,
     [new TestInitSignRequestBuilder(null as any, null as any)._id]: TestInitSignRequestBuilder,

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -189,7 +189,7 @@ class UserContextSignRequestBuilder extends HumanReadableModelBuilder {
 export class OffboardSignRequestBuilder extends HumanReadableModelBuilder {
     _name = "Offboard";
     _version = "1";
-    _humanReadableName = "Cancel Tide Subscription and Protection";
+    _humanReadableName = "Offboard from the Tide network (cancel subscription and protection)";
 
     get _id() { return this._name + ":" + this._version; }
     constructor(data, reqId) {
@@ -197,12 +197,9 @@ export class OffboardSignRequestBuilder extends HumanReadableModelBuilder {
     }
     getDetailsMap(): any {
         let summary: any = {};
-        summary["WARNING WARNING WARNING"] = "";
-        summary["APPROVING THIS REQUEST WILL CRIPPLE YOUR LICENSED TIDE ACCOUNT"] = "";
-        summary["ONLY APPROVE THIS REQUEST IF YOU INTEND TO OFFBOARD FROM THE TIDE NETWORK"] = "";
-        summary["THIS ACTION IS UNRECOVERABLE"] = "";
-
-
+        summary["WARNING"] = "Warning: approving this offboards your account from the Tide network. It cancels your subscription and Tide protection, and cannot be undone.";
+        summary["You are about to"] = "Offboard this account from the Tide network";
+        summary["Note"] = "Only approve this if you intend to permanently offboard from the Tide network.";
         return summary;
     }
     getRequestDataJson() {
@@ -595,26 +592,78 @@ const ATTESTATION_UNIT_TYPE_NAMES: { [k: number]: string } = {
 // this map we render the HONEST raw action ("Governance change: <node>") — never
 // a fabricated grant.
 const NODE_ACTION_TITLES: { [action: string]: (label: string) => string } = {
-    DELETE_CLIENT: (l) => `Delete app ${l}`,
-    DELETE_CLIENT_SCOPE: (l) => `Delete client scope ${l}`,
-    DELETE_USER: (l) => `Delete user ${l}`,
-    DELETE_ROLE: (l) => `Delete role ${l}`,
-    DELETE_GROUP: (l) => `Delete group ${l}`,
-    DELETE_ORGANIZATION: (l) => `Delete organization ${l}`,
-    DISABLE_IGA: () => "Disable IGA governance on realm",
-    OFFBOARD_REALM: () => "Offboard realm from the Tide network",
-    CREATE_CLIENT: (l) => `Create app ${l}`,
-    CREATE_CLIENT_SCOPE: (l) => `Create client scope ${l}`,
-    CREATE_USER: (l) => `Create user ${l}`,
-    CREATE_ROLE: (l) => `Create role ${l}`,
-    CREATE_GROUP: (l) => `Create group ${l}`,
-    CREATE_ORGANIZATION: (l) => `Create organization ${l}`,
-    UPDATE_CLIENT_PROPERTY: (l) => `Update app ${l}`,
-    UPDATE_CLIENT_REDIRECT_URIS: (l) => `Update redirect URIs for app ${l}`,
-    UPDATE_CLIENT_WEB_ORIGINS: (l) => `Update web origins for app ${l}`,
-    UPDATE_CLIENT_SCOPE_PROPERTY: (l) => `Update client scope ${l}`,
-    UPDATE_PROTOCOL_MAPPER: (l) => `Update protocol mapper ${l}`,
-    UPDATE_ORGANIZATION: (l) => `Update organization ${l}`,
+    DELETE_CLIENT: (l) => `Delete the app "${l}"`,
+    DELETE_CLIENT_SCOPE: (l) => `Delete the client scope "${l}"`,
+    DELETE_USER: (l) => `Delete the user "${l}"`,
+    DELETE_ROLE: (l) => `Delete the role "${l}"`,
+    DELETE_GROUP: (l) => `Delete the group "${l}"`,
+    DELETE_ORGANIZATION: (l) => `Delete the organization "${l}"`,
+    DISABLE_IGA: () => "Turn off governance (QEA) for this realm",
+    OFFBOARD_REALM: () => "Offboard (permanently shut down) this realm",
+    CREATE_CLIENT: (l) => `Create the app "${l}"`,
+    CREATE_CLIENT_SCOPE: (l) => `Create the client scope "${l}"`,
+    CREATE_USER: (l) => `Create the user "${l}"`,
+    CREATE_ROLE: (l) => `Create the role "${l}"`,
+    CREATE_GROUP: (l) => `Create the group "${l}"`,
+    CREATE_ORGANIZATION: (l) => `Create the organization "${l}"`,
+    UPDATE_CLIENT_PROPERTY: (l) => `Update the app "${l}"`,
+    UPDATE_CLIENT_REDIRECT_URIS: (l) => `Update the redirect URIs for app "${l}"`,
+    UPDATE_CLIENT_WEB_ORIGINS: (l) => `Update the web origins for app "${l}"`,
+    UPDATE_CLIENT_SCOPE_PROPERTY: (l) => `Update the client scope "${l}"`,
+    UPDATE_PROTOCOL_MAPPER: (l) => `Update the protocol mapper "${l}"`,
+    UPDATE_ORGANIZATION: (l) => `Update the organization "${l}"`,
+};
+
+// Per-action, plain-language consequence line for destructive actions, styled
+// with the WARNING/severity convention the enclave page already understands (see
+// OffboardSignRequestBuilder). Accurate, non-alarmist, no em dashes.
+const NODE_DESTRUCTIVE_WARNINGS: { [action: string]: string } = {
+    DELETE_CLIENT: "Warning: this permanently removes the app and all access through it. Apps and users relying on it will stop working.",
+    DELETE_CLIENT_SCOPE: "Warning: this permanently removes the client scope. Apps that depend on it may lose claims or stop working.",
+    DELETE_USER: "Warning: this permanently removes the user and their access. This cannot be undone.",
+    DELETE_ROLE: "Warning: this permanently removes the role. Users and groups holding it will lose the access it granted.",
+    DELETE_GROUP: "Warning: this permanently removes the group. Members will lose any access the group granted.",
+    DELETE_ORGANIZATION: "Warning: this permanently removes the organization and its associations. This cannot be undone.",
+    DISABLE_IGA: "Warning: this turns off approval governance for the whole realm. Future admin changes will apply without approval.",
+    OFFBOARD_REALM: "Warning: this permanently shuts the realm down. This cannot be undone.",
+};
+
+// Friendly, plain-language noun for the artifact each entity type refers to, used
+// in the "You are about to <verb> a/an <noun>" details line and as the primary
+// labelled field. Falls back to the raw entityType when not mapped.
+const NODE_ENTITY_NOUNS: { [entityType: string]: string } = {
+    CLIENT: "App",
+    CLIENT_SCOPE: "Client scope",
+    USER: "User",
+    ROLE: "Role",
+    GROUP: "Group",
+    ORGANIZATION: "Organization",
+    REALM: "Realm",
+};
+
+// Plain-language verb phrase for the "You are about to ..." details line, keyed on
+// the action prefix. Keeps the consequence summary readable without a raw action.
+const NODE_ACTION_VERBS: { [action: string]: string } = {
+    DELETE_CLIENT: "Delete an app",
+    DELETE_CLIENT_SCOPE: "Delete a client scope",
+    DELETE_USER: "Delete a user",
+    DELETE_ROLE: "Delete a role",
+    DELETE_GROUP: "Delete a group",
+    DELETE_ORGANIZATION: "Delete an organization",
+    DISABLE_IGA: "Turn off governance for this realm",
+    OFFBOARD_REALM: "Permanently shut this realm down",
+    CREATE_CLIENT: "Create an app",
+    CREATE_CLIENT_SCOPE: "Create a client scope",
+    CREATE_USER: "Create a user",
+    CREATE_ROLE: "Create a role",
+    CREATE_GROUP: "Create a group",
+    CREATE_ORGANIZATION: "Create an organization",
+    UPDATE_CLIENT_PROPERTY: "Update an app",
+    UPDATE_CLIENT_REDIRECT_URIS: "Update an app's redirect URIs",
+    UPDATE_CLIENT_WEB_ORIGINS: "Update an app's web origins",
+    UPDATE_CLIENT_SCOPE_PROPERTY: "Update a client scope",
+    UPDATE_PROTOCOL_MAPPER: "Update a protocol mapper",
+    UPDATE_ORGANIZATION: "Update an organization",
 };
 
 // node ACTIONs that destroy/cripple governed state — flagged in the details so the
@@ -633,7 +682,20 @@ const NODE_LABEL_FIELDS: { [entityType: string]: string[] } = {
     ROLE: ["ROLE_NAME"],
     GROUP: ["GROUP_NAME"],
     ORGANIZATION: ["ORG_NAME", "NAME", "ALIAS"],
+    REALM: ["REALM_NAME", "NAME"],
 };
+
+// Row fields that are noisy internal identifiers (raw UUIDs / *_UUID / *_ID
+// surrogate keys). These are never surfaced as primary friendly fields; at most a
+// single one is tucked under a secondary "Technical id" line.
+const NODE_NOISY_FIELDS = new Set<string>([
+    "CLIENT_UUID", "USER_UUID", "ROLE_UUID", "GROUP_UUID", "SCOPE_UUID",
+    "CLIENT_SCOPE_UUID", "ORG_UUID", "ID", "REALM_ID",
+]);
+
+// Row field, per entityType, whose value is the human-friendly NAME of the
+// artifact (shown as the primary labelled field in the details map).
+const NODE_PRIMARY_NAME_FIELD: { [entityType: string]: string[] } = NODE_LABEL_FIELDS;
 
 // Parsed shape of a canonicalizeNode plaintext draft segment.
 interface ParsedNodeCanonical {
@@ -817,8 +879,8 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
         if (linkage) {
             const owner = linkage.owners[0]?.owner;
             const ownerName = owner ? this._userName(owner) : undefined;
-            if (ownerName && ownerName !== owner) return `Role/membership assignment update for ${ownerName}`;
-            return "Role/membership assignment update";
+            if (ownerName && ownerName !== owner) return `Update the roles for user "${ownerName}"`;
+            return "Update the roles for a user";
         }
         // 3) CBOR units — structural type only.
         const units = this._decodeUnits();
@@ -839,13 +901,13 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
             // in the details map, not asserted as a grant in the title.
             const payload = first["payload"];
             const userName = this._titleUserName(payload);
-            if (userName) return `Role assignment update for ${userName}`;
-            return "Role assignment update";
+            if (userName) return `Update the roles for user "${userName}"`;
+            return "Update the roles for a user";
         }
 
         // Any other attestation unit: give a readable, type-specific title that is
         // honest about the artifact type without asserting an action verb.
-        if (utName) return `Approve change - ${utName.replace(/_/g, " ")}`;
+        if (utName) return `Approve change: ${utName.replace(/_/g, " ")}`;
         return undefined;
     }
 
@@ -918,24 +980,78 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
         } catch { return undefined; }
     }
 
+    // Find the human-friendly NAME of the realm this CR applies to, if a row
+    // carries one. The signed rows usually carry only REALM_ID (a UUID/surrogate),
+    // so a friendly realm name is shown only when REALM_NAME (or NAME on a REALM
+    // node) is present. Returns undefined when no friendly name is available.
+    private _realmName(node: ParsedNodeCanonical): string | undefined {
+        for (const row of node.rows) {
+            const v = row["REALM_NAME"];
+            if (typeof v === "string" && v.length > 0) return v;
+        }
+        if (node.entityType === "REALM") {
+            const lbl = this._nodeLabel(node);
+            if (lbl && lbl !== "(unspecified)") return lbl;
+        }
+        return undefined;
+    }
+
+    // A single secondary "Technical id" value, when one is genuinely useful and not
+    // already shown as a friendly name: prefer the entityId, else a noisy *_UUID/ID
+    // row field. Returns undefined when there is nothing meaningful to tuck away.
+    private _technicalId(node: ParsedNodeCanonical, primaryName: string | undefined): string | undefined {
+        if (typeof node.entityId === "string" && node.entityId.length > 0
+            && node.entityId !== "null" && node.entityId !== primaryName) {
+            return node.entityId;
+        }
+        for (const row of node.rows) {
+            for (const k of Object.keys(row)) {
+                if (NODE_NOISY_FIELDS.has(k) && k !== "REALM_ID") {
+                    const v = row[k];
+                    if (typeof v === "string" && v.length > 0 && v !== primaryName) return v;
+                }
+            }
+        }
+        return undefined;
+    }
+
     // Details for a canonicalizeNode plaintext draft (DELETE_*/DISABLE_IGA/...):
-    // the TRUE action + the parsed rows the admin is approving. Destructive actions
-    // are flagged with the same WARNING convention the Offboard builder uses.
+    // a small set of friendly, labelled fields stating exactly what the admin is
+    // approving, plus a prominent plain-language consequence line for destructive
+    // actions (reusing the enclave WARNING/severity convention). No raw row= blob,
+    // no raw UUID surfaced as a primary field.
     private _nodeDetails(node: ParsedNodeCanonical, summary: any): void {
+        // 1) Prominent destructive consequence line, styled by the enclave WARNING
+        //    convention. Per-action wording when known, generic otherwise.
         if (NODE_DESTRUCTIVE_ACTIONS.has(node.node)) {
-            summary["WARNING"] = "This is a destructive governance action and may be unrecoverable.";
+            summary["WARNING"] = NODE_DESTRUCTIVE_WARNINGS[node.node]
+                ?? "Warning: this is a destructive governance action and may be unrecoverable.";
         }
-        summary["Action"] = node.node;
-        if (node.entityType) summary["Entity Type"] = node.entityType;
-        if (typeof node.entityId === "string" && node.entityId.length > 0 && node.entityId !== "null") {
-            summary["Entity Id"] = node.entityId;
+
+        // 2) Plain "You are about to <verb>" line so the admin reads the intent in
+        //    one sentence (falls back to the raw action only for unknown actions).
+        summary["You are about to"] = NODE_ACTION_VERBS[node.node] ?? `Apply governance action: ${node.node}`;
+
+        // 3) The primary friendly NAME of the artifact, under a plain noun label
+        //    ("App"/"User"/"Role"/...). Falls back to the signed entityId only when
+        //    no name is resolvable, so a missing name never blanks the card.
+        const noun = (node.entityType && NODE_ENTITY_NOUNS[node.entityType]) || undefined;
+        const primaryName = this._nodeLabel(node);
+        const hasFriendly = primaryName && primaryName !== "(unspecified)";
+        if (noun && hasFriendly) {
+            summary[noun] = primaryName;
+        } else if (hasFriendly && node.entityType !== "REALM") {
+            summary["Name"] = primaryName;
         }
-        node.rows.forEach((row, i) => {
-            const keys = Object.keys(row);
-            if (keys.length === 0) return;
-            const rendered = keys.map((k) => `${k}=${row[k]}`).join(", ");
-            summary[node.rows.length > 1 ? `Row ${i + 1}` : "Details"] = rendered;
-        });
+
+        // 4) The realm this applies to, by friendly name when present.
+        const realm = this._realmName(node);
+        if (realm) summary["Realm"] = realm;
+
+        // 5) At most one secondary technical id, tucked away (never a primary field,
+        //    never a row= blob). Omitted entirely when nothing useful remains.
+        const tech = this._technicalId(node, hasFriendly ? primaryName : undefined);
+        if (tech) summary["Technical id"] = tech;
     }
 
     // Details for a canonicalizeLinkageSet plaintext draft (role/group/composite
@@ -943,16 +1059,18 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
     // display-only context. The verb (grant vs revoke) is NOT in the signed bytes,
     // so we explicitly note that the resulting set is shown, not the operation.
     private _linkageDetails(linkage: ParsedLinkageCanonical, summary: any): void {
-        summary["Table"] = linkage.table;
-        summary["Note"] = "Showing the resulting set after this change. The signed bytes do not record whether members were added or removed.";
+        const single = linkage.owners.length === 1;
         linkage.owners.forEach((o) => {
             const ownerName = this._userName(o.owner);
             const resolved = o.members.map((m) => {
                 const r = this._roleName(m);
                 return r !== m ? r : this._userName(m);
             });
-            summary[`Members of ${ownerName}`] = resolved.length > 0 ? resolved.join(", ") : "(none)";
+            if (single) summary["For"] = ownerName;
+            const label = single ? "Roles after this change" : `Roles after this change for ${ownerName}`;
+            summary[label] = resolved.length > 0 ? resolved.join(", ") : "(none)";
         });
+        summary["Note"] = "The system records the resulting set of roles. The signed approval does not record whether roles were added or removed.";
     }
 
     getDetailsMap(): any {
@@ -993,19 +1111,20 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
                     // UUIDs. The signed bytes still carry only UUIDs.
                     //
                     // NOTE: we surface the TARGET and the RESULTING role set under
-                    // neutral keys ("Target User", "Roles"). We do NOT assert an
-                    // action ("Grant role(s) to user"): the draft carries no action
-                    // verb, and user_role_mapping_set is a declarative set that may
-                    // be granting OR revoking. Showing the resulting set without a
-                    // verb is the honest, provable rendering.
-                    if (payload["user_id"] !== undefined) summary["Target User"] = this._userName(payload["user_id"]);
+                    // neutral, friendly labels ("User", "Roles after this change").
+                    // We do NOT assert an action ("Grant role(s) to user"): the draft
+                    // carries no action verb, and user_role_mapping_set is a
+                    // declarative set that may be granting OR revoking. Showing the
+                    // resulting set without a verb is the honest, provable rendering.
+                    if (payload["user_id"] !== undefined) summary["User"] = this._userName(payload["user_id"]);
                     const roleIds = payload["role_ids"];
                     if (Array.isArray(roleIds) && roleIds.length > 0) {
-                        summary["Roles"] = roleIds.map((r: any) => this._roleName(r)).join(", ");
+                        summary["Roles after this change"] = roleIds.map((r: any) => this._roleName(r)).join(", ");
+                        summary["Note"] = "The system records the resulting set of roles. The signed approval does not record whether roles were added or removed.";
                     }
                 }
-                if (first["target_id"] !== undefined && summary["Target User"] === undefined) {
-                    summary["Target"] = String(first["target_id"]);
+                if (first["target_id"] !== undefined && summary["User"] === undefined) {
+                    summary["Technical id"] = String(first["target_id"]);
                 }
             }
             if (units.length > 1) summary["Units In Request"] = units.length;

--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -572,6 +572,148 @@ const ATTESTATION_UNIT_TYPE_NAMES: { [k: number]: string } = {
     17: "organization_domain_set",
 };
 
+// -----------------------------------------------------------------------------
+// Producer "canonicalizeNode" plaintext (the NODE / non-linkage CR family).
+//
+// For a NON-producer CR (DELETE_*, DISABLE_IGA, ...) the carrier's draft segment
+// is NOT a CBOR AttestationUnit envelope: it is the VERBATIM UTF-8 plaintext that
+// iga-core's TideAttestor.canonicalizeNode emits and signs (the bytes the admin
+// approves), shaped as:
+//
+//   node=<ACTION>\n
+//   entityType=<ENTITY>\n
+//   entityId=<id>\n
+//   row=<k=v;k=v;...>\n        (one or more, keys sorted, rows sorted)
+//
+// This is FULLY self-describing — `node=<ACTION>` is the TRUE CR action, present
+// in the signed bytes, so for this family we render the accurate action+data.
+//
+// `node` ACTION -> faithful human title. The {0} placeholder is filled from the
+// most human-friendly row field for that entity (e.g. CLIENT_ID, USERNAME, NAME)
+// falling back to the entityId. Verified against the producer CR creation sites
+// (IgaRealmProvider / IgaUserProvider recordAndThrow rows). For an action NOT in
+// this map we render the HONEST raw action ("Governance change: <node>") — never
+// a fabricated grant.
+const NODE_ACTION_TITLES: { [action: string]: (label: string) => string } = {
+    DELETE_CLIENT: (l) => `Delete app ${l}`,
+    DELETE_CLIENT_SCOPE: (l) => `Delete client scope ${l}`,
+    DELETE_USER: (l) => `Delete user ${l}`,
+    DELETE_ROLE: (l) => `Delete role ${l}`,
+    DELETE_GROUP: (l) => `Delete group ${l}`,
+    DELETE_ORGANIZATION: (l) => `Delete organization ${l}`,
+    DISABLE_IGA: () => "Disable IGA governance on realm",
+    OFFBOARD_REALM: () => "Offboard realm from the Tide network",
+    CREATE_CLIENT: (l) => `Create app ${l}`,
+    CREATE_CLIENT_SCOPE: (l) => `Create client scope ${l}`,
+    CREATE_USER: (l) => `Create user ${l}`,
+    CREATE_ROLE: (l) => `Create role ${l}`,
+    CREATE_GROUP: (l) => `Create group ${l}`,
+    CREATE_ORGANIZATION: (l) => `Create organization ${l}`,
+    UPDATE_CLIENT_PROPERTY: (l) => `Update app ${l}`,
+    UPDATE_CLIENT_REDIRECT_URIS: (l) => `Update redirect URIs for app ${l}`,
+    UPDATE_CLIENT_WEB_ORIGINS: (l) => `Update web origins for app ${l}`,
+    UPDATE_CLIENT_SCOPE_PROPERTY: (l) => `Update client scope ${l}`,
+    UPDATE_PROTOCOL_MAPPER: (l) => `Update protocol mapper ${l}`,
+    UPDATE_ORGANIZATION: (l) => `Update organization ${l}`,
+};
+
+// node ACTIONs that destroy/cripple governed state — flagged in the details so the
+// admin sees the same WARNING severity convention the Offboard builder uses.
+const NODE_DESTRUCTIVE_ACTIONS = new Set<string>([
+    "DELETE_CLIENT", "DELETE_CLIENT_SCOPE", "DELETE_USER", "DELETE_ROLE",
+    "DELETE_GROUP", "DELETE_ORGANIZATION", "DISABLE_IGA", "OFFBOARD_REALM",
+]);
+
+// Preferred human-friendly row field per entityType, most-specific first. Used to
+// label the title with a name the admin recognises instead of a raw UUID.
+const NODE_LABEL_FIELDS: { [entityType: string]: string[] } = {
+    CLIENT: ["CLIENT_ID"],
+    CLIENT_SCOPE: ["CLIENT_SCOPE_NAME"],
+    USER: ["USERNAME"],
+    ROLE: ["ROLE_NAME"],
+    GROUP: ["GROUP_NAME"],
+    ORGANIZATION: ["ORG_NAME", "NAME", "ALIAS"],
+};
+
+// Parsed shape of a canonicalizeNode plaintext draft segment.
+interface ParsedNodeCanonical {
+    node: string;
+    entityType: string | undefined;
+    entityId: string | undefined;
+    rows: { [k: string]: string }[];
+}
+
+// Parsed shape of a canonicalizeLinkageSet plaintext draft segment.
+interface ParsedLinkageCanonical {
+    table: string;
+    // one entry per owner, in the order emitted; members is the resulting set.
+    owners: { owner: string; members: string[] }[];
+}
+
+// UTF-8 decode the segment bytes, tolerating non-UTF-8 (returns "" on failure so
+// the caller falls through to the CBOR / neutral path; never throws).
+function decodeUtf8Loose(bytes: Uint8Array): string {
+    try { return StringFromUint8Array(bytes); } catch { return ""; }
+}
+
+// Parse a canonicalizeNode plaintext segment. Returns undefined when the bytes are
+// not the `node=...` plaintext shape (so the caller tries CBOR / neutral). Never
+// throws. Mirrors iga-core TideAttestor.canonicalizeNode byte-for-byte: lines are
+// '\n'-delimited; each `row=` line is `k=v;k=v;...` with `;` between pairs and the
+// FIRST `=` separating key from value (values may themselves contain `=`).
+function parseNodeCanonical(text: string): ParsedNodeCanonical | undefined {
+    if (!text.startsWith("node=")) return undefined;
+    const lines = text.split("\n");
+    let node = "", entityType: string | undefined, entityId: string | undefined;
+    const rows: { [k: string]: string }[] = [];
+    for (const line of lines) {
+        if (line.length === 0) continue;
+        if (line.startsWith("node=")) node = line.substring("node=".length);
+        else if (line.startsWith("entityType=")) entityType = line.substring("entityType=".length);
+        else if (line.startsWith("entityId=")) entityId = line.substring("entityId=".length);
+        else if (line.startsWith("row=")) {
+            const body = line.substring("row=".length);
+            const row: { [k: string]: string } = {};
+            if (body.length > 0) {
+                for (const pair of body.split(";")) {
+                    const eq = pair.indexOf("=");
+                    if (eq < 0) continue;
+                    row[pair.substring(0, eq)] = pair.substring(eq + 1);
+                }
+            }
+            rows.push(row);
+        }
+    }
+    if (node.length === 0) return undefined;
+    return { node, entityType, entityId, rows };
+}
+
+// Parse a canonicalizeLinkageSet plaintext segment. Returns undefined when the
+// bytes are not the `table=...` plaintext shape. Never throws. Mirrors iga-core
+// TideAttestor.canonicalizeLinkageSet: `table=<t>\n` then per owner
+// `owner=<id>\nmembers=<m1,m2,...>\n` (members comma-joined, possibly empty).
+function parseLinkageCanonical(text: string): ParsedLinkageCanonical | undefined {
+    if (!text.startsWith("table=")) return undefined;
+    const lines = text.split("\n");
+    let table = "";
+    const owners: { owner: string; members: string[] }[] = [];
+    let currentOwner: string | undefined;
+    for (const line of lines) {
+        if (line.length === 0) continue;
+        if (line.startsWith("table=")) table = line.substring("table=".length);
+        else if (line.startsWith("owner=")) {
+            currentOwner = line.substring("owner=".length);
+            owners.push({ owner: currentOwner, members: [] });
+        } else if (line.startsWith("members=")) {
+            const body = line.substring("members=".length);
+            const members = body.length > 0 ? body.split(",") : [];
+            if (owners.length > 0) owners[owners.length - 1].members = members;
+        }
+    }
+    if (table.length === 0) return undefined;
+    return { table, owners };
+}
+
 class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
     _name = "AttestationUnit";
     _version = "1";
@@ -600,20 +742,85 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
         } catch { /* keep the neutral "Governance change" title */ }
     }
 
+    // Lazily decode draft segment 0 as UTF-8 and try the two producer plaintext
+    // canonical shapes. Cached so repeated title/details calls parse once. Never
+    // throws; returns the parsed form or undefined when the segment is not that
+    // plaintext (CBOR unit, empty, or garbage), in which case callers fall through
+    // to the CBOR / neutral path.
+    private _nodeCanon: ParsedNodeCanonical | undefined | null = null;     // null = not yet computed
+    private _linkageCanon: ParsedLinkageCanonical | undefined | null = null;
+    private _firstSegmentText(): string {
+        try {
+            if (!this._draft) return "";
+            const res: any = {};
+            if (!TryGetValue(this._draft, 0, res)) return "";
+            const bytes = res.result;
+            if (!bytes || bytes.length === 0) return "";
+            return decodeUtf8Loose(bytes);
+        } catch { return ""; }
+    }
+    private _getNodeCanonical(): ParsedNodeCanonical | undefined {
+        if (this._nodeCanon === null) {
+            try { this._nodeCanon = parseNodeCanonical(this._firstSegmentText()); }
+            catch { this._nodeCanon = undefined; }
+        }
+        return this._nodeCanon ?? undefined;
+    }
+    private _getLinkageCanonical(): ParsedLinkageCanonical | undefined {
+        if (this._linkageCanon === null) {
+            try { this._linkageCanon = parseLinkageCanonical(this._firstSegmentText()); }
+            catch { this._linkageCanon = undefined; }
+        }
+        return this._linkageCanon ?? undefined;
+    }
+
+    // Pick the most human-friendly label for a node CR from its parsed rows
+    // (e.g. CLIENT_ID, USERNAME, NAME), falling back to the entityId, then "(?)".
+    private _nodeLabel(node: ParsedNodeCanonical): string {
+        const fields = (node.entityType && NODE_LABEL_FIELDS[node.entityType]) || [];
+        for (const row of node.rows) {
+            for (const f of fields) {
+                const v = row[f];
+                if (typeof v === "string" && v.length > 0) return v;
+            }
+        }
+        if (typeof node.entityId === "string" && node.entityId.length > 0
+            && node.entityId !== "null") return node.entityId;
+        return "(unspecified)";
+    }
+
     // Compute a specific, human-readable card title for the carried unit, using
     // the display-only HumanReadableContext (role/user names) when present.
     //
-    // HONESTY CONTRACT: the signed draft carries only the structural `unit_type`
-    // (realm_config, client_config, ... user_role_mapping_set) + payloads. It does
-    // NOT carry the CR action verb (grant/delete/create/update/revoke), so we
-    // CANNOT prove delete-vs-edit-vs-create from the bytes. This method therefore
-    // NEVER asserts an action verb. It describes the artifact TYPE honestly
-    // ("Approve change - client config") and, for role-assignment, uses neutral
-    // "Role assignment update" wording (the unit is a declarative set carrying
-    // both grants AND revokes - see comment below). Returns undefined only when no
-    // unit can be decoded, so the caller keeps the neutral "Governance change"
-    // fallback. There is NO code path here that yields a "Grant ..." title.
+    // HONESTY CONTRACT, by draft shape:
+    //   - canonicalizeNode plaintext (`node=<ACTION>...`): the TRUE action IS in the
+    //     signed bytes, so render it ACCURATELY ("Delete app my-client", "Disable
+    //     IGA governance on realm"). Unknown action -> honest "Governance change:
+    //     <node>", never a grant.
+    //   - canonicalizeLinkageSet plaintext (`table=...`): the resulting member SET
+    //     is in the bytes but the VERB is NOT (grant vs revoke are byte-identical),
+    //     so render NEUTRAL "Role/membership assignment update" + the members.
+    //   - CBOR AttestationUnit: structural `unit_type` only, no verb -> neutral
+    //     type-specific title (existing behaviour).
+    // Returns undefined only when nothing can be decoded, so the caller keeps the
+    // neutral "Governance change" fallback. There is NO path that fabricates a grant.
     private _buildTitle(): string | undefined {
+        // 1) NODE plaintext — true action present in signed bytes.
+        const node = this._getNodeCanonical();
+        if (node) {
+            const titleFn = NODE_ACTION_TITLES[node.node];
+            if (titleFn) return titleFn(this._nodeLabel(node));
+            return `Governance change: ${node.node}`;
+        }
+        // 2) LINKAGE plaintext — set present, verb NOT present -> neutral.
+        const linkage = this._getLinkageCanonical();
+        if (linkage) {
+            const owner = linkage.owners[0]?.owner;
+            const ownerName = owner ? this._userName(owner) : undefined;
+            if (ownerName && ownerName !== owner) return `Role/membership assignment update for ${ownerName}`;
+            return "Role/membership assignment update";
+        }
+        // 3) CBOR units — structural type only.
         const units = this._decodeUnits();
         const first = units[0];
         if (!first || typeof first !== "object") return undefined;
@@ -711,9 +918,61 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
         } catch { return undefined; }
     }
 
+    // Details for a canonicalizeNode plaintext draft (DELETE_*/DISABLE_IGA/...):
+    // the TRUE action + the parsed rows the admin is approving. Destructive actions
+    // are flagged with the same WARNING convention the Offboard builder uses.
+    private _nodeDetails(node: ParsedNodeCanonical, summary: any): void {
+        if (NODE_DESTRUCTIVE_ACTIONS.has(node.node)) {
+            summary["WARNING"] = "This is a destructive governance action and may be unrecoverable.";
+        }
+        summary["Action"] = node.node;
+        if (node.entityType) summary["Entity Type"] = node.entityType;
+        if (typeof node.entityId === "string" && node.entityId.length > 0 && node.entityId !== "null") {
+            summary["Entity Id"] = node.entityId;
+        }
+        node.rows.forEach((row, i) => {
+            const keys = Object.keys(row);
+            if (keys.length === 0) return;
+            const rendered = keys.map((k) => `${k}=${row[k]}`).join(", ");
+            summary[node.rows.length > 1 ? `Row ${i + 1}` : "Details"] = rendered;
+        });
+    }
+
+    // Details for a canonicalizeLinkageSet plaintext draft (role/group/composite
+    // SET actions): the RESULTING member set per owner, names resolved via the
+    // display-only context. The verb (grant vs revoke) is NOT in the signed bytes,
+    // so we explicitly note that the resulting set is shown, not the operation.
+    private _linkageDetails(linkage: ParsedLinkageCanonical, summary: any): void {
+        summary["Table"] = linkage.table;
+        summary["Note"] = "Showing the resulting set after this change. The signed bytes do not record whether members were added or removed.";
+        linkage.owners.forEach((o) => {
+            const ownerName = this._userName(o.owner);
+            const resolved = o.members.map((m) => {
+                const r = this._roleName(m);
+                return r !== m ? r : this._userName(m);
+            });
+            summary[`Members of ${ownerName}`] = resolved.length > 0 ? resolved.join(", ") : "(none)";
+        });
+    }
+
     getDetailsMap(): any {
         const summary: any = {};
         try {
+            // ---- producer plaintext canonical forms (true-action / neutral-set) -
+            const node = this._getNodeCanonical();
+            if (node) {
+                this._nodeDetails(node, summary);
+                this._appendTimingDetails(summary);
+                return summary;
+            }
+            const linkage = this._getLinkageCanonical();
+            if (linkage) {
+                this._linkageDetails(linkage, summary);
+                this._appendTimingDetails(summary);
+                return summary;
+            }
+
+            // ---- CBOR AttestationUnit path (structural type, no verb) ----------
             const units = this._decodeUnits();
             const policy = this._decodePolicy();
 
@@ -763,23 +1022,42 @@ class AttestationUnitSignRequestBuilder extends HumanReadableModelBuilder {
 
             // ---- timing (also surfaced by the enclave chrome; included here for
             //      a self-contained card, guarded so it never throws) ------------
-            try {
-                if (this.request && typeof this.request.expiry === "number") {
-                    summary["Expires"] = new Date(this.request.expiry * 1000).toUTCString();
-                }
-            } catch { /* expiry not readable */ }
-            try {
-                if (this.request && this.request.isInitialized()) {
-                    summary["Requested At"] = new Date(this.request.getInitializedTime() * 1000).toUTCString();
-                }
-            } catch { /* not initialized */ }
+            this._appendTimingDetails(summary);
         } catch { /* never throw from the summary builder */ }
         return summary;
+    }
+
+    // Append the request expiry / requested-at lines, each individually guarded so
+    // a missing/uninitialized field never throws out of the summary builder.
+    private _appendTimingDetails(summary: any): void {
+        try {
+            if (this.request && typeof this.request.expiry === "number") {
+                summary["Expires"] = new Date(this.request.expiry * 1000).toUTCString();
+            }
+        } catch { /* expiry not readable */ }
+        try {
+            if (this.request && this.request.isInitialized()) {
+                summary["Requested At"] = new Date(this.request.getInitializedTime() * 1000).toUTCString();
+            }
+        } catch { /* not initialized */ }
     }
 
     getRequestDataJson(): any {
         const data: any = {};
         try {
+            // Producer plaintext canonical forms render their parsed structure
+            // (the raw JSON view mirrors the accurate-vs-neutral details split).
+            const node = this._getNodeCanonical();
+            if (node) {
+                data["node"] = { action: node.node, entityType: node.entityType, entityId: node.entityId, rows: node.rows };
+                return data;
+            }
+            const linkage = this._getLinkageCanonical();
+            if (linkage) {
+                data["linkageSet"] = { table: linkage.table, owners: linkage.owners };
+                return data;
+            }
+
             const units = this._decodeUnits();
             // Render bytes as hex so the JSON view is clean (decodeCbor only yields
             // Uint8Array for CBOR byte-strings, which the unit payloads don't use,

--- a/Models/Policy.ts
+++ b/Models/Policy.ts
@@ -1,5 +1,7 @@
 import { TideMemory } from "../Tools/TideMemory";
 import { BigIntToByteArray, BigIntFromByteArray, StringFromUint8Array, StringToUint8Array } from "../Cryptide/Serialization";
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
 
 export enum ApprovalType {
     EXPLICIT,
@@ -70,7 +72,7 @@ export class Policy {
                 case PolicyV2.thisVersion:
                     return PolicyV2.from(d);
                 default:
-                    throw Error("Unknown policy version: " + version);
+                    throw new TideError({ code: TideJsErrorCodes.MODEL_VERSION_MISMATCH, displayMessage: `Unknown policy version: ${version}`, source: "tide-js/Models/Policy.ts:75" });
             }
         }
 
@@ -171,7 +173,7 @@ export class PolicyParameters {
                     datum = new Uint8Array(dataBytes);
                     break;
                 default:
-                    throw new Error(`Could not find type of ${type}`);
+                    throw new TideError({ code: TideJsErrorCodes.MODEL_UNKNOWN_PARAM_TYPE, displayMessage: `PolicyParameters.fromBytes: could not find type of ${type}`, source: "tide-js/Models/Policy.ts:176" });
             }
 
             params.set(name, datum);
@@ -190,7 +192,7 @@ export class PolicyParameters {
 
     getParameter<T extends string | number | bigint | boolean | Uint8Array>(key: string): T {
         if (!this.entries.has(key)) {
-            throw new Error(`Parameter '${key}' not found`);
+            throw new TideError({ code: TideJsErrorCodes.MODEL_PARAM_NOT_FOUND, displayMessage: `PolicyParameters.getParameter: parameter '${key}' not found`, source: "tide-js/Models/Policy.ts:195" });
         }
 
         const value = this.entries.get(key);
@@ -214,9 +216,7 @@ export class PolicyParameters {
             (value instanceof Uint8Array);
 
         if (!isCorrectType) {
-            throw new Error(
-                `Parameter '${key}' exists but has unexpected type '${actualType}'`
-            );
+            throw new TideError({ code: TideJsErrorCodes.MODEL_INVALID_FIELD, displayMessage: `PolicyParameters.getParameter: parameter '${key}' exists but has unexpected type '${actualType}'`, source: "tide-js/Models/Policy.ts:219" });
         }
 
         return value as T;
@@ -248,9 +248,7 @@ export class PolicyParameters {
                 dataBytes = value;
                 typeStr = "byt";
             } else {
-                throw new Error(
-                    `Could not serialize key '${key}' of type '${typeof value}'`
-                );
+                throw new TideError({ code: TideJsErrorCodes.MODEL_UNKNOWN_PARAM_TYPE, displayMessage: `PolicyParameters.toBytes: could not serialize key '${key}' of type '${typeof value}'`, source: "tide-js/Models/Policy.ts:253" });
             }
 
             const typeBytes = StringToUint8Array(typeStr);
@@ -268,7 +266,7 @@ class PolicyV2 extends Policy{
         const dataToVerify = data.GetValue(0);
         const v = StringFromUint8Array(dataToVerify.GetValue(0));
         if (v != PolicyV2.thisVersion) {
-            throw Error("Dev error");
+            throw new TideError({ code: TideJsErrorCodes.MODEL_DEV_ERROR, displayMessage: `PolicyV2.from: version mismatch (expected ${PolicyV2.thisVersion}, got ${v})`, source: "tide-js/Models/Policy.ts:273" });
         }
 
         const contractId = StringFromUint8Array(dataToVerify.GetValue(1));
@@ -320,7 +318,7 @@ class PolicyV1 extends Policy {
         const dataToVerify = data.GetValue(0);
         const v = StringFromUint8Array(dataToVerify.GetValue(0));
         if (v != PolicyV1.thisVersion) {
-            throw Error("Dev error");
+            throw new TideError({ code: TideJsErrorCodes.MODEL_DEV_ERROR, displayMessage: `PolicyV1.from: version mismatch (expected ${PolicyV1.thisVersion}, got ${v})`, source: "tide-js/Models/Policy.ts:325" });
         }
 
         const contractId = StringFromUint8Array(dataToVerify.GetValue(1));

--- a/Models/PolicyProtectedSerializedField.ts
+++ b/Models/PolicyProtectedSerializedField.ts
@@ -18,6 +18,8 @@
 import { Uint8ArrayToNumber, numberToUint8Array } from "../Cryptide/Serialization";
 import {  Serialization } from "../Cryptide/index";
 import { TideMemory } from "../Tools/TideMemory";
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
 
 export default class PolicyProtectedSerializedField{
     static version = 2;
@@ -36,7 +38,7 @@ export default class PolicyProtectedSerializedField{
     static deserialize(serializedField: Uint8Array){
         // Make sure version is 1
         const version = Uint8ArrayToNumber(Serialization.GetValue(serializedField, 0));
-        if(version != this.version) throw Error("Serialized tide data must be version " + this.version);
+        if(version != this.version) throw new TideError({ code: TideJsErrorCodes.MODEL_VERSION_MISMATCH, displayMessage: `PolicyProtectedSerializedField.deserialize: expected version ${this.version} (got ${version})`, source: "tide-js/Models/PolicyProtectedSerializedField.ts:41" });
 
         const encFieldChk = Serialization.GetValue(serializedField, 1);
         const timestamp = Serialization.GetValue(serializedField, 2); // keep as array until JS HANDLES 64 BIT NUMBERS!

--- a/Models/SerializedField.ts
+++ b/Models/SerializedField.ts
@@ -18,6 +18,8 @@
 import { Uint8ArrayToNumber, numberToUint8Array } from "../Cryptide/Serialization";
 import {  Serialization } from "../Cryptide/index";
 import { TideMemory } from "../Tools/TideMemory";
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
 
 export default class SerializedField{
     static version = 1;
@@ -36,7 +38,7 @@ export default class SerializedField{
     static deserialize(serializedField: Uint8Array){
         // Make sure version is 1
         const version = Uint8ArrayToNumber(Serialization.GetValue(serializedField, 0));
-        if(version != this.version) throw Error("Serialized tide data must be version " + this.version);
+        if(version != this.version) throw new TideError({ code: TideJsErrorCodes.MODEL_VERSION_MISMATCH, displayMessage: `SerializedField.deserialize: expected version ${this.version} (got ${version})`, source: "tide-js/Models/SerializedField.ts:41" });
 
         const encFieldChk = Serialization.GetValue(serializedField, 1);
         const timestamp = Serialization.GetValue(serializedField, 2); // keep as array until JS HANDLES 64 BIT NUMBERS!

--- a/Tests/ModelRegistryLabels.ts
+++ b/Tests/ModelRegistryLabels.ts
@@ -57,6 +57,14 @@ function buildRequest(unitBytesList: Uint8Array[]): Uint8Array {
     return req.encode();
 }
 
+// Build an AttestationUnit:1 request whose single draft segment is the verbatim
+// UTF-8 plaintext that iga-core's canonicalizeNode / canonicalizeLinkageSet emits
+// (the non-producer carrier path: SetUnits(new byte[][]{ canonicalForRegularCr })).
+function buildPlaintextRequest(text: string): Uint8Array {
+    const seg = new TextEncoder().encode(text);
+    return buildRequest([seg]);
+}
+
 // ---- assertions -------------------------------------------------------------
 let failures = 0;
 function check(name: string, cond: boolean, extra?: any) {
@@ -131,6 +139,82 @@ console.log("AttestationUnit safe-label tests:");
     check("urms no-context title neutral",
         b._humanReadableName === "Role assignment update", b._humanReadableName);
     assertNoGrant(b, "user_role_mapping_set-no-ctx");
+}
+
+// ---- canonicalizeNode plaintext: TRUE action rendered from signed bytes -----
+
+// 4) DELETE_CLIENT node -> "Delete app <clientId>" + rows + destructive WARNING
+{
+    const text = "node=DELETE_CLIENT\nentityType=CLIENT\nentityId=client-uuid\n" +
+        "row=CLIENT_ID=acme;CLIENT_UUID=client-uuid;REALM_ID=r1\n";
+    const b = ModelRegistry.getHumanReadableModelBuilder("r4", buildPlaintextRequest(text));
+    check("DELETE_CLIENT title uses friendly clientId",
+        b._humanReadableName === "Delete app acme", b._humanReadableName);
+    const d = b.getDetailsMap();
+    check("DELETE_CLIENT details Action", d["Action"] === "DELETE_CLIENT", d["Action"]);
+    check("DELETE_CLIENT details has rows", typeof d["Details"] === "string" && d["Details"].includes("CLIENT_ID=acme"), d["Details"]);
+    check("DELETE_CLIENT flagged destructive", typeof d["WARNING"] === "string" && d["WARNING"].length > 0, d["WARNING"]);
+    assertNoGrant(b, "DELETE_CLIENT");
+}
+
+// 4b) DELETE_USER node -> "Delete user <username>"
+{
+    const text = "node=DELETE_USER\nentityType=USER\nentityId=u1\nrow=REALM_ID=r1;USERNAME=bob;USER_ID=u1\n";
+    const b = ModelRegistry.getHumanReadableModelBuilder("r4b", buildPlaintextRequest(text));
+    check("DELETE_USER title uses username",
+        b._humanReadableName === "Delete user bob", b._humanReadableName);
+    assertNoGrant(b, "DELETE_USER");
+}
+
+// 5) DISABLE_IGA node -> fixed realm title
+{
+    const text = "node=DISABLE_IGA\nentityType=REALM\nentityId=r1\n";
+    const b = ModelRegistry.getHumanReadableModelBuilder("r5", buildPlaintextRequest(text));
+    check("DISABLE_IGA title",
+        b._humanReadableName === "Disable IGA governance on realm", b._humanReadableName);
+    const d = b.getDetailsMap();
+    check("DISABLE_IGA flagged destructive", typeof d["WARNING"] === "string" && d["WARNING"].length > 0, d["WARNING"]);
+    assertNoGrant(b, "DISABLE_IGA");
+}
+
+// 5b) unknown node=FOO -> honest "Governance change: FOO", never a grant
+{
+    const text = "node=FOO_BAR\nentityType=THING\nentityId=x1\nrow=K=v\n";
+    const b = ModelRegistry.getHumanReadableModelBuilder("r5b", buildPlaintextRequest(text));
+    check("unknown node honest title",
+        b._humanReadableName === "Governance change: FOO_BAR", b._humanReadableName);
+    const d = b.getDetailsMap();
+    check("unknown node details Action raw", d["Action"] === "FOO_BAR", d["Action"]);
+    assertNoGrant(b, "unknown-node");
+}
+
+// ---- canonicalizeLinkageSet plaintext: NEUTRAL set, no grant/revoke assertion -
+
+// 6) linkage set -> neutral role/membership update + resolved members, NO verb
+{
+    const text = "table=user_role_mapping\nowner=user-uuid-1\nmembers=role-uuid-a,role-uuid-b\n";
+    const ctx = { users: { "user-uuid-1": "alice" }, roles: { "role-uuid-a": "tide-realm-admin", "role-uuid-b": "viewer" } };
+    const b = ModelRegistry.getHumanReadableModelBuilder("r6", buildPlaintextRequest(text), ctx);
+    check("linkage title neutral+named",
+        b._humanReadableName === "Role/membership assignment update for alice", b._humanReadableName);
+    assertNoGrant(b, "linkage-set");
+    const d = b.getDetailsMap();
+    check("linkage details Table", d["Table"] === "user_role_mapping", d["Table"]);
+    check("linkage members resolved",
+        typeof d["Members of alice"] === "string" && d["Members of alice"].includes("tide-realm-admin"), d["Members of alice"]);
+    check("linkage notes resulting-set, no verb",
+        typeof d["Note"] === "string" && !/revok|grant/i.test(d["Note"]), d["Note"]);
+    // must NOT assert revoke either
+    check("linkage title has no 'revoke'", !/revoke/i.test(String(b._humanReadableName)), b._humanReadableName);
+}
+
+// 6b) linkage set, empty resulting members -> "(none)", still neutral
+{
+    const text = "table=user_role_mapping\nowner=user-uuid-1\nmembers=\n";
+    const b = ModelRegistry.getHumanReadableModelBuilder("r6b", buildPlaintextRequest(text));
+    check("linkage empty members neutral title",
+        b._humanReadableName === "Role/membership assignment update", b._humanReadableName);
+    assertNoGrant(b, "linkage-empty");
 }
 
 console.log(failures === 0

--- a/Tests/ModelRegistryLabels.ts
+++ b/Tests/ModelRegistryLabels.ts
@@ -1,0 +1,139 @@
+//
+// Tide Protocol - Infrastructure for a TRUE Zero-Trust paradigm
+// Copyright (C) 2022 Tide Foundation Ltd
+//
+// Standalone verification for the "safe-label" fix to the approval-enclave
+// summary builder (AttestationUnitSignRequestBuilder in Models/ModelRegistry.ts).
+//
+// Run with:  npx tsx Tests/ModelRegistryLabels.ts
+//
+// Asserts that NOTHING ever falsely renders as a grant:
+//   - a client_config-only draft  -> "Approve change - client config" (NOT a grant)
+//   - an empty / undecodable draft -> neutral "Governance change"
+//   - a user_role_mapping_set draft -> neutral "Role assignment update ..." + Roles
+//
+
+import { ModelRegistry } from "../Models/ModelRegistry";
+import BaseTideRequest from "../Models/BaseTideRequest";
+import { CreateTideMemoryFromArray } from "../Cryptide/Serialization";
+
+// ---- tiny CBOR encoder (definite-length) for fixtures ----------------------
+// Mirrors the small subset decodeCbor() in ModelRegistry handles: unsigned ints,
+// text strings, arrays and maps.
+function head(major: number, n: number): number[] {
+    if (n < 24) return [(major << 5) | n];
+    if (n < 0x100) return [(major << 5) | 24, n];
+    if (n < 0x10000) return [(major << 5) | 25, (n >> 8) & 0xff, n & 0xff];
+    return [(major << 5) | 26, (n >>> 24) & 0xff, (n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
+function enc(v: any): number[] {
+    if (typeof v === "number") return head(0, v);
+    if (typeof v === "string") {
+        const b = Array.from(new TextEncoder().encode(v));
+        return [...head(3, b.length), ...b];
+    }
+    if (Array.isArray(v)) {
+        const out = head(4, v.length);
+        for (const item of v) out.push(...enc(item));
+        return out;
+    }
+    if (v && typeof v === "object") {
+        const keys = Object.keys(v);
+        const out = head(5, keys.length);
+        for (const k of keys) { out.push(...enc(k)); out.push(...enc(v[k])); }
+        return out;
+    }
+    throw new Error("unsupported fixture value: " + String(v));
+}
+function cbor(v: any): Uint8Array { return new Uint8Array(enc(v)); }
+
+// Build an encoded AttestationUnit:1 request whose draft segments are the given
+// verbatim-CBOR unit byte arrays (req.SetUnits(byte[][]) on the producer side).
+function buildRequest(unitBytesList: Uint8Array[]): Uint8Array {
+    const draft = unitBytesList.length
+        ? CreateTideMemoryFromArray(unitBytesList)
+        : new Uint8Array();
+    const req = new BaseTideRequest("AttestationUnit", "1", "", draft);
+    return req.encode();
+}
+
+// ---- assertions -------------------------------------------------------------
+let failures = 0;
+function check(name: string, cond: boolean, extra?: any) {
+    if (cond) { console.log(`  PASS  ${name}`); }
+    else { console.log(`  FAIL  ${name}`, extra ?? ""); failures++; }
+}
+function assertNoGrant(builder: any, name: string) {
+    const title = String(builder._humanReadableName ?? "");
+    const detailsStr = JSON.stringify(builder.getDetailsMap());
+    check(`${name}: title has no 'grant'`, !/grant/i.test(title), title);
+    check(`${name}: details have no 'grant'`, !/grant/i.test(detailsStr), detailsStr);
+}
+
+console.log("AttestationUnit safe-label tests:");
+
+// 1) client_config-only draft -> "Approve change - client config", never a grant
+{
+    const unit = cbor({ unit_type: 1 /* client_config */, payload: { client_id: "my-client" } });
+    const b = ModelRegistry.getHumanReadableModelBuilder("r1", buildRequest([unit]));
+    check("client_config title", b._humanReadableName === "Approve change - client config", b._humanReadableName);
+    assertNoGrant(b, "client_config");
+}
+
+// 2) empty draft -> neutral "Governance change", never a grant
+{
+    const b = ModelRegistry.getHumanReadableModelBuilder("r2", buildRequest([]));
+    check("empty draft title", b._humanReadableName === "Governance change", b._humanReadableName);
+    assertNoGrant(b, "empty");
+}
+
+// 2b) undecodable / garbage draft -> neutral "Governance change", never a grant
+{
+    const garbage = new Uint8Array([0xff, 0xff, 0xff, 0xff]);
+    const b = ModelRegistry.getHumanReadableModelBuilder("r2b", buildRequest([garbage]));
+    check("garbage draft title", b._humanReadableName === "Governance change", b._humanReadableName);
+    assertNoGrant(b, "garbage");
+}
+
+// 2c) unknown unit_type ordinal -> "Approve change - 99", never a grant
+{
+    const unit = cbor({ unit_type: 99, payload: {} });
+    const b = ModelRegistry.getHumanReadableModelBuilder("r2c", buildRequest([unit]));
+    check("unknown ordinal not a grant", !/grant/i.test(String(b._humanReadableName)), b._humanReadableName);
+    assertNoGrant(b, "unknown-ordinal");
+}
+
+// 3) user_role_mapping_set draft -> neutral role-assignment wording + Roles,
+//    NEVER "Grant"
+{
+    const unit = cbor({
+        unit_type: 7 /* user_role_mapping_set */,
+        payload: { user_id: "user-uuid-1", role_ids: ["role-uuid-a", "role-uuid-b"] },
+    });
+    const ctx = { users: { "user-uuid-1": "alice" }, roles: { "role-uuid-a": "tide-realm-admin" } };
+    const b = ModelRegistry.getHumanReadableModelBuilder("r3", buildRequest([unit]), ctx);
+    check("urms title neutral+named",
+        b._humanReadableName === "Role assignment update for alice", b._humanReadableName);
+    assertNoGrant(b, "user_role_mapping_set");
+    const details = b.getDetailsMap();
+    check("urms details Target User = alice", details["Target User"] === "alice", details["Target User"]);
+    check("urms details Roles resolved", typeof details["Roles"] === "string" && details["Roles"].includes("tide-realm-admin"), details["Roles"]);
+    check("urms details has no Action key", details["Action"] === undefined, details["Action"]);
+}
+
+// 3b) user_role_mapping_set WITHOUT context -> neutral generic, no UUID-grant
+{
+    const unit = cbor({
+        unit_type: 7,
+        payload: { user_id: "user-uuid-1", role_ids: ["role-uuid-a"] },
+    });
+    const b = ModelRegistry.getHumanReadableModelBuilder("r3b", buildRequest([unit]));
+    check("urms no-context title neutral",
+        b._humanReadableName === "Role assignment update", b._humanReadableName);
+    assertNoGrant(b, "user_role_mapping_set-no-ctx");
+}
+
+console.log(failures === 0
+    ? "\nALL PASS"
+    : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/Tests/ModelRegistryLabels.ts
+++ b/Tests/ModelRegistryLabels.ts
@@ -78,14 +78,47 @@ function assertNoGrant(builder: any, name: string) {
     check(`${name}: details have no 'grant'`, !/grant/i.test(detailsStr), detailsStr);
 }
 
+// No user-facing string may contain an em dash (U+2014). Checks the title + every
+// key AND value in the details map.
+function assertNoEmDash(builder: any, name: string) {
+    const title = String(builder._humanReadableName ?? "");
+    const details = builder.getDetailsMap();
+    let bad = title.includes("—");
+    if (!bad && details && typeof details === "object") {
+        for (const k of Object.keys(details)) {
+            if (String(k).includes("—") || String(details[k]).includes("—")) { bad = true; break; }
+        }
+    }
+    check(`${name}: no em dash in any user-facing string`, !bad, title + " | " + JSON.stringify(details));
+}
+
+// No details value may be a raw `row=key=value;...` blob, and no raw UUID may
+// appear as a PRIMARY field value (a value matching the canonical UUID shape that
+// is not under the secondary "Technical id" label).
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+function assertNoRawBlobOrPrimaryUuid(builder: any, name: string) {
+    const details = builder.getDetailsMap();
+    let blob = false, primaryUuid = false;
+    if (details && typeof details === "object") {
+        for (const k of Object.keys(details)) {
+            const v = String(details[k]);
+            if (/row=/.test(v) || /^\s*\w+=\w+;/.test(v)) blob = true;
+            if (k !== "Technical id" && UUID_RE.test(v.trim())) primaryUuid = true;
+        }
+    }
+    check(`${name}: no row= blob in details`, !blob, JSON.stringify(details));
+    check(`${name}: no raw UUID as a primary field`, !primaryUuid, JSON.stringify(details));
+}
+
 console.log("AttestationUnit safe-label tests:");
 
-// 1) client_config-only draft -> "Approve change - client config", never a grant
+// 1) client_config-only draft -> "Approve change: client config", never a grant
 {
     const unit = cbor({ unit_type: 1 /* client_config */, payload: { client_id: "my-client" } });
     const b = ModelRegistry.getHumanReadableModelBuilder("r1", buildRequest([unit]));
-    check("client_config title", b._humanReadableName === "Approve change - client config", b._humanReadableName);
+    check("client_config title", b._humanReadableName === "Approve change: client config", b._humanReadableName);
     assertNoGrant(b, "client_config");
+    assertNoEmDash(b, "client_config");
 }
 
 // 2) empty draft -> neutral "Governance change", never a grant
@@ -93,6 +126,7 @@ console.log("AttestationUnit safe-label tests:");
     const b = ModelRegistry.getHumanReadableModelBuilder("r2", buildRequest([]));
     check("empty draft title", b._humanReadableName === "Governance change", b._humanReadableName);
     assertNoGrant(b, "empty");
+    assertNoEmDash(b, "empty");
 }
 
 // 2b) undecodable / garbage draft -> neutral "Governance change", never a grant
@@ -121,12 +155,14 @@ console.log("AttestationUnit safe-label tests:");
     const ctx = { users: { "user-uuid-1": "alice" }, roles: { "role-uuid-a": "tide-realm-admin" } };
     const b = ModelRegistry.getHumanReadableModelBuilder("r3", buildRequest([unit]), ctx);
     check("urms title neutral+named",
-        b._humanReadableName === "Role assignment update for alice", b._humanReadableName);
+        b._humanReadableName === 'Update the roles for user "alice"', b._humanReadableName);
     assertNoGrant(b, "user_role_mapping_set");
+    assertNoEmDash(b, "user_role_mapping_set");
     const details = b.getDetailsMap();
-    check("urms details Target User = alice", details["Target User"] === "alice", details["Target User"]);
-    check("urms details Roles resolved", typeof details["Roles"] === "string" && details["Roles"].includes("tide-realm-admin"), details["Roles"]);
+    check("urms details User = alice", details["User"] === "alice", details["User"]);
+    check("urms details Roles resolved", typeof details["Roles after this change"] === "string" && details["Roles after this change"].includes("tide-realm-admin"), details["Roles after this change"]);
     check("urms details has no Action key", details["Action"] === undefined, details["Action"]);
+    check("urms details has resulting-set note", typeof details["Note"] === "string" && !/grant|revok/i.test(details["Note"]), details["Note"]);
 }
 
 // 3b) user_role_mapping_set WITHOUT context -> neutral generic, no UUID-grant
@@ -137,44 +173,73 @@ console.log("AttestationUnit safe-label tests:");
     });
     const b = ModelRegistry.getHumanReadableModelBuilder("r3b", buildRequest([unit]));
     check("urms no-context title neutral",
-        b._humanReadableName === "Role assignment update", b._humanReadableName);
+        b._humanReadableName === "Update the roles for a user", b._humanReadableName);
     assertNoGrant(b, "user_role_mapping_set-no-ctx");
+    assertNoEmDash(b, "user_role_mapping_set-no-ctx");
 }
 
 // ---- canonicalizeNode plaintext: TRUE action rendered from signed bytes -----
 
-// 4) DELETE_CLIENT node -> "Delete app <clientId>" + rows + destructive WARNING
+// 4) DELETE_CLIENT node -> 'Delete the app "<clientId>"' + friendly fields +
+//    destructive WARNING; NO row= blob, NO raw UUID as a primary field.
 {
-    const text = "node=DELETE_CLIENT\nentityType=CLIENT\nentityId=client-uuid\n" +
-        "row=CLIENT_ID=acme;CLIENT_UUID=client-uuid;REALM_ID=r1\n";
+    const text = "node=DELETE_CLIENT\nentityType=CLIENT\nentityId=11111111-2222-3333-4444-555555555555\n" +
+        "row=CLIENT_ID=acme-portal;CLIENT_UUID=11111111-2222-3333-4444-555555555555;REALM_NAME=acme;REALM_ID=r1\n";
     const b = ModelRegistry.getHumanReadableModelBuilder("r4", buildPlaintextRequest(text));
-    check("DELETE_CLIENT title uses friendly clientId",
-        b._humanReadableName === "Delete app acme", b._humanReadableName);
+    check("DELETE_CLIENT title friendly+quoted",
+        b._humanReadableName === 'Delete the app "acme-portal"', b._humanReadableName);
     const d = b.getDetailsMap();
-    check("DELETE_CLIENT details Action", d["Action"] === "DELETE_CLIENT", d["Action"]);
-    check("DELETE_CLIENT details has rows", typeof d["Details"] === "string" && d["Details"].includes("CLIENT_ID=acme"), d["Details"]);
-    check("DELETE_CLIENT flagged destructive", typeof d["WARNING"] === "string" && d["WARNING"].length > 0, d["WARNING"]);
+    check("DELETE_CLIENT details friendly verb", d["You are about to"] === "Delete an app", d["You are about to"]);
+    check("DELETE_CLIENT details App = name", d["App"] === "acme-portal", d["App"]);
+    check("DELETE_CLIENT details Realm = name", d["Realm"] === "acme", d["Realm"]);
+    check("DELETE_CLIENT flagged destructive w/ consequence",
+        typeof d["WARNING"] === "string" && /permanently removes the app/.test(d["WARNING"]), d["WARNING"]);
+    check("DELETE_CLIENT no raw Action key", d["Action"] === undefined, d["Action"]);
     assertNoGrant(b, "DELETE_CLIENT");
+    assertNoEmDash(b, "DELETE_CLIENT");
+    assertNoRawBlobOrPrimaryUuid(b, "DELETE_CLIENT");
 }
 
-// 4b) DELETE_USER node -> "Delete user <username>"
+// 4b) DELETE_USER node -> 'Delete the user "<username>"'
 {
     const text = "node=DELETE_USER\nentityType=USER\nentityId=u1\nrow=REALM_ID=r1;USERNAME=bob;USER_ID=u1\n";
     const b = ModelRegistry.getHumanReadableModelBuilder("r4b", buildPlaintextRequest(text));
     check("DELETE_USER title uses username",
-        b._humanReadableName === "Delete user bob", b._humanReadableName);
+        b._humanReadableName === 'Delete the user "bob"', b._humanReadableName);
+    const d = b.getDetailsMap();
+    check("DELETE_USER details User = name", d["User"] === "bob", d["User"]);
     assertNoGrant(b, "DELETE_USER");
+    assertNoEmDash(b, "DELETE_USER");
+    assertNoRawBlobOrPrimaryUuid(b, "DELETE_USER");
 }
 
-// 5) DISABLE_IGA node -> fixed realm title
+// 5) DISABLE_IGA node -> fixed realm title + governance-off consequence
 {
     const text = "node=DISABLE_IGA\nentityType=REALM\nentityId=r1\n";
     const b = ModelRegistry.getHumanReadableModelBuilder("r5", buildPlaintextRequest(text));
     check("DISABLE_IGA title",
-        b._humanReadableName === "Disable IGA governance on realm", b._humanReadableName);
+        b._humanReadableName === "Turn off governance (QEA) for this realm", b._humanReadableName);
     const d = b.getDetailsMap();
-    check("DISABLE_IGA flagged destructive", typeof d["WARNING"] === "string" && d["WARNING"].length > 0, d["WARNING"]);
+    check("DISABLE_IGA flagged destructive w/ consequence",
+        typeof d["WARNING"] === "string" && /turns off approval governance/.test(d["WARNING"]), d["WARNING"]);
     assertNoGrant(b, "DISABLE_IGA");
+    assertNoEmDash(b, "DISABLE_IGA");
+    assertNoRawBlobOrPrimaryUuid(b, "DISABLE_IGA");
+}
+
+// 5c) OFFBOARD_REALM node -> friendly title + unrecoverable consequence
+{
+    const text = "node=OFFBOARD_REALM\nentityType=REALM\nentityId=r1\nrow=REALM_NAME=acme\n";
+    const b = ModelRegistry.getHumanReadableModelBuilder("r5c", buildPlaintextRequest(text));
+    check("OFFBOARD_REALM title",
+        b._humanReadableName === "Offboard (permanently shut down) this realm", b._humanReadableName);
+    const d = b.getDetailsMap();
+    check("OFFBOARD_REALM consequence cannot be undone",
+        typeof d["WARNING"] === "string" && /cannot be undone/i.test(d["WARNING"]), d["WARNING"]);
+    check("OFFBOARD_REALM realm name shown", d["Realm"] === "acme", d["Realm"]);
+    assertNoGrant(b, "OFFBOARD_REALM");
+    assertNoEmDash(b, "OFFBOARD_REALM");
+    assertNoRawBlobOrPrimaryUuid(b, "OFFBOARD_REALM");
 }
 
 // 5b) unknown node=FOO -> honest "Governance change: FOO", never a grant
@@ -184,8 +249,10 @@ console.log("AttestationUnit safe-label tests:");
     check("unknown node honest title",
         b._humanReadableName === "Governance change: FOO_BAR", b._humanReadableName);
     const d = b.getDetailsMap();
-    check("unknown node details Action raw", d["Action"] === "FOO_BAR", d["Action"]);
+    check("unknown node details honest verb", d["You are about to"] === "Apply governance action: FOO_BAR", d["You are about to"]);
     assertNoGrant(b, "unknown-node");
+    assertNoEmDash(b, "unknown-node");
+    assertNoRawBlobOrPrimaryUuid(b, "unknown-node");
 }
 
 // ---- canonicalizeLinkageSet plaintext: NEUTRAL set, no grant/revoke assertion -
@@ -196,12 +263,13 @@ console.log("AttestationUnit safe-label tests:");
     const ctx = { users: { "user-uuid-1": "alice" }, roles: { "role-uuid-a": "tide-realm-admin", "role-uuid-b": "viewer" } };
     const b = ModelRegistry.getHumanReadableModelBuilder("r6", buildPlaintextRequest(text), ctx);
     check("linkage title neutral+named",
-        b._humanReadableName === "Role/membership assignment update for alice", b._humanReadableName);
+        b._humanReadableName === 'Update the roles for user "alice"', b._humanReadableName);
     assertNoGrant(b, "linkage-set");
+    assertNoEmDash(b, "linkage-set");
     const d = b.getDetailsMap();
-    check("linkage details Table", d["Table"] === "user_role_mapping", d["Table"]);
-    check("linkage members resolved",
-        typeof d["Members of alice"] === "string" && d["Members of alice"].includes("tide-realm-admin"), d["Members of alice"]);
+    check("linkage details For = alice", d["For"] === "alice", d["For"]);
+    check("linkage roles-after resolved",
+        typeof d["Roles after this change"] === "string" && d["Roles after this change"].includes("tide-realm-admin"), d["Roles after this change"]);
     check("linkage notes resulting-set, no verb",
         typeof d["Note"] === "string" && !/revok|grant/i.test(d["Note"]), d["Note"]);
     // must NOT assert revoke either
@@ -213,8 +281,11 @@ console.log("AttestationUnit safe-label tests:");
     const text = "table=user_role_mapping\nowner=user-uuid-1\nmembers=\n";
     const b = ModelRegistry.getHumanReadableModelBuilder("r6b", buildPlaintextRequest(text));
     check("linkage empty members neutral title",
-        b._humanReadableName === "Role/membership assignment update", b._humanReadableName);
+        b._humanReadableName === "Update the roles for a user", b._humanReadableName);
+    check("linkage empty members shows (none)",
+        b.getDetailsMap()["Roles after this change"] === "(none)", b.getDetailsMap()["Roles after this change"]);
     assertNoGrant(b, "linkage-empty");
+    assertNoEmDash(b, "linkage-empty");
 }
 
 console.log(failures === 0

--- a/Tests/ReservationErrors.test.mjs
+++ b/Tests/ReservationErrors.test.mjs
@@ -2,6 +2,11 @@
 //   1. Case-tolerant ProblemDetails parsing (Clients/ClientBase.ts)
 //   2. `_get` problem+json pass-through on non-ok statuses
 //   3. Opt-in unanimous-code promotion in PromiseRace (Tools/Utils.ts)
+//   4. Phase 4 security hardening:
+//      - true-unanimity gate (partial failure sets never promote)
+//      - median representative selection (honest-majority, non-finite never wins)
+//      - ProblemDetails field validation (drop/truncate, never throw)
+//      - promoted-messageKey namespace guard (error(s).tide.* only)
 //
 // Runs against the compiled `dist/` output (see the `test` script in
 // package.json — `tsc` is run first). Browser APIs are not required: the
@@ -154,21 +159,121 @@ test("_getSilent: 409 problem+json throws the structured pass-through error", as
 });
 
 // ---------------------------------------------------------------------------
-// 3. PromiseRace unanimous-code promotion (via WaitForNumberofORKs)
+// 3. ProblemDetails field validation (drop/truncate, never throw)
 // ---------------------------------------------------------------------------
 
-function reservedFailure(expirySeconds) {
+test("validation: 1MB PascalCase Detail is truncated to 2048, no throw", async () => {
+    const huge = "A".repeat(1024 * 1024);
+    const body = JSON.stringify({
+        Status: 409,
+        Detail: huge,
+        Code: RESERVED_CODE,
+        MessageKey: RESERVED_KEY,
+        MessageParams: { minutes: "3" },
+    });
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() => client._handleError(problemResponse(body), "x"));
+    assert.equal(err.code, RESERVED_CODE);
+    assert.equal(err.displayMessage.length, 2048, "detail must be truncated to 2048 chars");
+});
+
+test("validation: __proto__ key in messageParams is dropped without prototype pollution", async () => {
+    // Raw string so JSON.parse (not an object literal) produces the own
+    // `__proto__` data property, exactly like a hostile wire body would.
+    const body = `{"Status":409,"Code":"${RESERVED_CODE}","Detail":"d",`
+        + `"MessageParams":{"__proto__":{"polluted":"yes"},"constructor":"x","minutes":"3"}}`;
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() => client._handleError(problemResponse(body), "x"));
+    assert.equal(err.code, RESERVED_CODE);
+    assert.deepEqual(err.messageParams, { minutes: "3" },
+        "__proto__/constructor keys must be dropped");
+    assert.ok(!Object.prototype.hasOwnProperty.call(err.messageParams, "__proto__"));
+    assert.equal({}.polluted, undefined, "Object.prototype must not be polluted");
+});
+
+test("validation: messageParams capped at 16 keys, values String()-coerced and truncated to 256", async () => {
+    const params = {};
+    for (let i = 0; i < 50; i++) params[`k${i}`] = i < 1 ? "B".repeat(5000) : 42;
+    const body = JSON.stringify({ Status: 409, Code: RESERVED_CODE, Detail: "d", MessageParams: params });
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() => client._handleError(problemResponse(body), "x"));
+    assert.equal(err.code, RESERVED_CODE);
+    assert.equal(Object.keys(err.messageParams).length, 16, "at most 16 keys kept");
+    assert.equal(err.messageParams.k0.length, 256, "values truncated to 256");
+    assert.equal(err.messageParams.k1, "42", "values coerced via String()");
+});
+
+test("validation: messageParams keys outside ^[A-Za-z0-9_]{1,64}$ are dropped", async () => {
+    const body = JSON.stringify({
+        Status: 409, Code: RESERVED_CODE, Detail: "d",
+        MessageParams: { "minutes": "3", "bad key!": "x", ["L".repeat(65)]: "y" },
+    });
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() => client._handleError(problemResponse(body), "x"));
+    assert.deepEqual(err.messageParams, { minutes: "3" });
+});
+
+test("validation: non-object / array messageParams degrades to null, no throw", async () => {
+    const client = new ClientBase("http://ork.example");
+    for (const bad of ['"a string"', "[1,2,3]", "12"]) {
+        const body = `{"Status":409,"Code":"${RESERVED_CODE}","Detail":"d","MessageParams":${bad}}`;
+        const err = await expectThrow(() => client._handleError(problemResponse(body), "x"));
+        assert.equal(err.code, RESERVED_CODE);
+        assert.equal(err.messageParams, null);
+    }
+});
+
+test("validation: code failing the charset is DROPPED -> PARSE_PROBLEM_JSON_INVALID", async () => {
+    const body = JSON.stringify({ Status: 409, Code: "TIDE CODE WITH SPACES <script>", Detail: "d" });
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() => client._handleError(problemResponse(body), "x"));
+    assert.equal(err.code, TideJsErrorCodes.PARSE_PROBLEM_JSON_INVALID,
+        "an invalid code must degrade to the existing no-code fallback, not throw");
+});
+
+test("validation: code longer than 256 chars is dropped -> PARSE_PROBLEM_JSON_INVALID", async () => {
+    const body = JSON.stringify({ Status: 409, Code: "X".repeat(257), Detail: "d" });
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() => client._handleError(problemResponse(body), "x"));
+    assert.equal(err.code, TideJsErrorCodes.PARSE_PROBLEM_JSON_INVALID);
+});
+
+test("validation: messageKey failing the charset is dropped; non-string envelope fields dropped; traceId truncated", async () => {
+    const body = JSON.stringify({
+        Status: 409,
+        Code: RESERVED_CODE,
+        Detail: { not: "a string" },        // dropped -> falls back to Title
+        Title: "Username reserved",
+        MessageKey: "error.tide.x y<z>",    // charset fail -> dropped
+        TraceId: "T".repeat(1000),          // truncated to 256
+        Source: 12345,                      // dropped
+    });
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() => client._handleError(problemResponse(body), "x"));
+    assert.equal(err.code, RESERVED_CODE);
+    assert.equal(err.messageKey, null);
+    assert.equal(err.displayMessage, "Username reserved");
+    assert.equal(err.traceId.length, 256);
+    assert.equal(err.source, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// 4. PromiseRace unanimous-code promotion (via WaitForNumberofORKs)
+// ---------------------------------------------------------------------------
+
+function reservedFailure(minutes, extra = {}) {
     return new TideError({
         code: RESERVED_CODE,
         displayMessage: "This username was recently reserved by another sign-up attempt",
         messageKey: RESERVED_KEY,
-        messageParams: { minutes: "10", expirySeconds },
+        messageParams: minutes === undefined ? null : { minutes },
         httpStatus: 409,
         problemType: `urn:tide:errors:${RESERVED_CODE}`,
         traceId: "00-aaaabbbbccccddddeeeeffff00001111-2222333344445555-01",
         url: "http://ork.example/Network/Authentication/Users/GetReservers/uid123",
         endpoint: "/Network/Authentication/Users/GetReservers/uid123",
         method: "GET",
+        ...extra,
     });
 }
 
@@ -187,37 +292,112 @@ function raceWith(failures, opts) {
     return WaitForNumberofORKs([], promises, "CMK", failures.length, null, null, 50, null, opts);
 }
 
-test("promotion: unanimous reserved code is promoted, representative = largest expirySeconds", async () => {
-    const failures = [reservedFailure("100"), reservedFailure("300"), reservedFailure("200")];
+test("promotion: unanimous reserved code is promoted, representative = median minutes", async () => {
+    const failures = [reservedFailure("1"), reservedFailure("5"), reservedFailure("3")];
     const err = await expectThrow(() => raceWith(failures, { promoteUnanimousCodes: true }));
 
     assert.equal(err.name, "TideError", "promoted error must keep the TideError name invariant");
     assert.equal(err.code, RESERVED_CODE);
-    assert.equal(err.messageKey, RESERVED_KEY);
-    assert.deepEqual(err.messageParams, { minutes: "10", expirySeconds: "300" },
-        "representative must be the failure with the largest numeric expirySeconds");
+    assert.equal(err.messageKey, RESERVED_KEY, "in-namespace messageKey must survive promotion");
+    assert.deepEqual(err.messageParams, { minutes: "3" },
+        "representative must be the failure with the MEDIAN numeric minutes");
     assert.equal(err.httpStatus, 409);
     assert.equal(err.traceId, "00-aaaabbbbccccddddeeeeffff00001111-2222333344445555-01");
     assert.match(err.source, /promoted: 3 identical per-ORK failures/);
     assert.equal(err.details.length, 3, "aggregate details must be preserved");
-    assert.equal(err.cause, failures[1], "cause must be the representative failure");
+    assert.equal(err.cause, failures[2], "cause must be the representative (median) failure");
 });
 
-test("promotion: absent/NaN expirySeconds falls back to first failure", async () => {
-    const noExpiry = new TideError({
-        code: RESERVED_CODE,
-        displayMessage: "reserved (no params)",
-        messageKey: RESERVED_KEY,
-    });
-    const alsoNoExpiry = new TideError({
-        code: RESERVED_CODE,
-        displayMessage: "reserved (NaN params)",
-        messageKey: RESERVED_KEY,
-        messageParams: { expirySeconds: "not-a-number" },
-    });
-    const err = await expectThrow(() => raceWith([noExpiry, alsoNoExpiry], { promoteUnanimousCodes: true }));
+test("promotion: one inflated outlier never wins — median picks an honest value", async () => {
+    // 5-member cohort, 1 attacker inflating `minutes`: median is honest.
+    const failures = [
+        reservedFailure("2"), reservedFailure("3"), reservedFailure("999999"),
+        reservedFailure("2"), reservedFailure("3"),
+    ];
+    const err = await expectThrow(() => raceWith(failures, { promoteUnanimousCodes: true }));
     assert.equal(err.code, RESERVED_CODE);
-    assert.equal(err.cause, noExpiry);
+    assert.ok(["2", "3"].includes(err.messageParams.minutes),
+        `median must be an honest value, got minutes=${err.messageParams.minutes}`);
+});
+
+test("promotion: non-finite minutes ('9e999' / 'Infinity' / 'NaN') are never candidates", async () => {
+    const failures = [reservedFailure("9e999"), reservedFailure("Infinity"),
+        reservedFailure("NaN"), reservedFailure("4")];
+    const err = await expectThrow(() => raceWith(failures, { promoteUnanimousCodes: true }));
+    assert.equal(err.code, RESERVED_CODE);
+    assert.equal(err.messageParams.minutes, "4",
+        "the only finite value must be the representative; 9e999/Infinity must never win");
+});
+
+test("promotion: even candidate count takes the lower median", async () => {
+    const failures = [reservedFailure("1"), reservedFailure("2"), reservedFailure("3"), reservedFailure("4")];
+    const err = await expectThrow(() => raceWith(failures, { promoteUnanimousCodes: true }));
+    assert.equal(err.messageParams.minutes, "2", "even count -> lower median");
+});
+
+test("promotion: no numeric minutes falls back to median expirySeconds (older ORKs)", async () => {
+    const failures = [
+        reservedFailure(undefined, { messageParams: { expirySeconds: "100" } }),
+        reservedFailure(undefined, { messageParams: { expirySeconds: "300" } }),
+        reservedFailure(undefined, { messageParams: { expirySeconds: "200" } }),
+    ];
+    const err = await expectThrow(() => raceWith(failures, { promoteUnanimousCodes: true }));
+    assert.equal(err.code, RESERVED_CODE);
+    assert.deepEqual(err.messageParams, { expirySeconds: "200" },
+        "expirySeconds fallback must also be median-selected");
+});
+
+test("promotion: neither minutes nor expirySeconds numeric falls back to first failure", async () => {
+    const noParams = reservedFailure(undefined);
+    const nanParams = reservedFailure(undefined, { messageParams: { expirySeconds: "not-a-number" } });
+    const err = await expectThrow(() => raceWith([noParams, nanParams], { promoteUnanimousCodes: true }));
+    assert.equal(err.code, RESERVED_CODE);
+    assert.equal(err.cause, noParams);
+});
+
+test("promotion: partial failure set at timeout does NOT promote (Finding 1 reproducer)", async () => {
+    // One fast "malicious" ORK rejects with the reserved code; the other two
+    // honest ORKs never answer before the timeout. The failure set is
+    // unanimous-LOOKING but covers only 1 of 3 attempted — must NOT promote.
+    const hang = () => new Promise(() => {});
+    const promises = [Promise.reject(reservedFailure("3")), hang(), hang()];
+    const err = await expectThrow(() =>
+        WaitForNumberofORKs([], promises, "CMK", 3, null, null, 50, null, { promoteUnanimousCodes: true }));
+    assert.equal(err.code, TideJsErrorCodes.NET_THRESHOLD_FAILURE,
+        "truncated failure set must fall through to the generic aggregate");
+    assert.equal(err.details.length, 1);
+});
+
+test("promotion: failures + a success below threshold does NOT promote", async () => {
+    // 2 unanimous failures + 1 resolved promise, threshold 3: the failure set
+    // does not cover the attempted cohort (one member SUCCEEDED), so no
+    // cohort-attested claim can be made.
+    const promises = [
+        Promise.reject(reservedFailure("3")),
+        Promise.reject(reservedFailure("3")),
+        Promise.resolve({ ok: true, index: 0 }),
+    ];
+    const err = await expectThrow(() =>
+        WaitForNumberofORKs([], promises, "CMK", 3, null, null, 50, null, { promoteUnanimousCodes: true }));
+    assert.equal(err.code, TideJsErrorCodes.NET_THRESHOLD_FAILURE);
+});
+
+test("promotion: messageKey outside error(s).tide.* namespace is omitted", async () => {
+    const failures = [
+        reservedFailure("3", { messageKey: "enclave.login.welcomeBack" }),
+        reservedFailure("3", { messageKey: "enclave.login.welcomeBack" }),
+    ];
+    const err = await expectThrow(() => raceWith(failures, { promoteUnanimousCodes: true }));
+    assert.equal(err.code, RESERVED_CODE, "promotion itself must still happen");
+    assert.equal(err.messageKey, null,
+        "out-of-namespace messageKey must be omitted from the promoted error");
+});
+
+test("promotion: errors.tide.* (plural) namespace prefix is also accepted", async () => {
+    const key = "errors.tide.ork.keygen.username_reserved";
+    const failures = [reservedFailure("3", { messageKey: key }), reservedFailure("3", { messageKey: key })];
+    const err = await expectThrow(() => raceWith(failures, { promoteUnanimousCodes: true }));
+    assert.equal(err.messageKey, key);
 });
 
 test("promotion: mixed codes stay generic NET_THRESHOLD_FAILURE", async () => {

--- a/Tests/ReservationErrors.test.mjs
+++ b/Tests/ReservationErrors.test.mjs
@@ -1,0 +1,248 @@
+// Node unit tests for the reservation-error-surfacing changes:
+//   1. Case-tolerant ProblemDetails parsing (Clients/ClientBase.ts)
+//   2. `_get` problem+json pass-through on non-ok statuses
+//   3. Opt-in unanimous-code promotion in PromiseRace (Tools/Utils.ts)
+//
+// Runs against the compiled `dist/` output (see the `test` script in
+// package.json — `tsc` is run first). Browser APIs are not required: the
+// code paths under test only use `fetch` (stubbed here), `Response`,
+// `Headers` and `performance`, all available in Node >= 18.
+//
+// Run: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import ClientBase from "../dist/Clients/ClientBase.js";
+import { WaitForNumberofORKs } from "../dist/Tools/Utils.js";
+import { TideError } from "../dist/Errors/TideError.js";
+import { TideJsErrorCodes } from "../dist/Errors/codes.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const RESERVED_CODE = "TIDE-ORK-KEYGEN-USERNAME_RESERVED";
+const RESERVED_KEY = "error.tide.ork.keygen.username_reserved";
+
+/** The ork-side wire form: PascalCase envelope, string MessageParams values. */
+function pascalCaseBody(expirySeconds = "1765500000") {
+    return JSON.stringify({
+        Type: `urn:tide:errors:${RESERVED_CODE}`,
+        Title: "Username reserved",
+        Status: 409,
+        Detail: "This username was recently reserved by another sign-up attempt",
+        Code: RESERVED_CODE,
+        TraceId: "00-aaaabbbbccccddddeeeeffff00001111-2222333344445555-01",
+        Source: "Ork/KeyGeneration/Reservation.cs:88",
+        MessageKey: RESERVED_KEY,
+        MessageParams: { minutes: "10", expirySeconds },
+    });
+}
+
+/** Legacy / RFC 7807 lowercase form (must remain accepted for compat). */
+function lowercaseBody() {
+    return JSON.stringify({
+        type: `urn:tide:errors:${RESERVED_CODE}`,
+        title: "Username reserved",
+        status: 409,
+        detail: "This username was recently reserved by another sign-up attempt",
+        code: RESERVED_CODE,
+        traceId: "00-aaaabbbbccccddddeeeeffff00001111-2222333344445555-01",
+        source: "Ork/KeyGeneration/Reservation.cs:88",
+        messageKey: RESERVED_KEY,
+        messageParams: { minutes: "10", expirySeconds: "1765500000" },
+    });
+}
+
+function problemResponse(body, status = 409) {
+    return new Response(body, {
+        status,
+        headers: { "content-type": "application/problem+json" },
+    });
+}
+
+async function expectThrow(fn) {
+    try {
+        await fn();
+    } catch (e) {
+        return e;
+    }
+    assert.fail("expected the call to throw, but it resolved");
+}
+
+function assertStructuredReservedError(err) {
+    assert.equal(err.name, "TideError", "name invariant must hold");
+    assert.ok(TideError.isTideError(err));
+    assert.equal(err.code, RESERVED_CODE);
+    assert.equal(err.messageKey, RESERVED_KEY, "messageKey must pass through verbatim");
+    assert.deepEqual(err.messageParams, { minutes: "10", expirySeconds: "1765500000" });
+    assert.equal(err.httpStatus, 409);
+    assert.equal(err.problemType, `urn:tide:errors:${RESERVED_CODE}`);
+    assert.equal(err.traceId, "00-aaaabbbbccccddddeeeeffff00001111-2222333344445555-01");
+}
+
+// ---------------------------------------------------------------------------
+// 1. ProblemDetails parsing (_handleError)
+// ---------------------------------------------------------------------------
+
+test("_handleError parses PascalCase ProblemDetails (canonical ork wire form)", async () => {
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() =>
+        client._handleError(problemResponse(pascalCaseBody()), "Find Reservers"));
+    assertStructuredReservedError(err);
+});
+
+test("_handleError still parses lowercase ProblemDetails (compat)", async () => {
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() =>
+        client._handleError(problemResponse(lowercaseBody()), "Find Reservers"));
+    assertStructuredReservedError(err);
+});
+
+test("_handleError: non-JSON problem+json body falls back to PARSE_PROBLEM_JSON_INVALID", async () => {
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() =>
+        client._handleError(problemResponse("<<< not json >>>"), "Find Reservers"));
+    assert.equal(err.name, "TideError");
+    assert.equal(err.code, TideJsErrorCodes.PARSE_PROBLEM_JSON_INVALID);
+});
+
+test("_handleError: problem+json object without code/Code falls back to PARSE_PROBLEM_JSON_INVALID", async () => {
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() =>
+        client._handleError(problemResponse(JSON.stringify({ Title: "nope", Status: 409 })), "x"));
+    assert.equal(err.code, TideJsErrorCodes.PARSE_PROBLEM_JSON_INVALID);
+});
+
+// ---------------------------------------------------------------------------
+// 2. _get problem+json pass-through
+// ---------------------------------------------------------------------------
+
+test("_get: 409 problem+json throws the structured pass-through error", async (t) => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async () => problemResponse(pascalCaseBody());
+    t.after(() => { globalThis.fetch = realFetch; });
+
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() =>
+        client._get("/Network/Authentication/Users/GetReservers/uid123"));
+    assertStructuredReservedError(err);
+    assert.equal(err.method, "GET");
+    assert.equal(err.url, "http://ork.example/Network/Authentication/Users/GetReservers/uid123");
+});
+
+test("_get: non-problem+json 409 still throws NET_NON_OK_STATUS", async (t) => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+        new Response("Conflict", { status: 409, headers: { "content-type": "text/plain" } });
+    t.after(() => { globalThis.fetch = realFetch; });
+
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() => client._get("/some/endpoint"));
+    assert.equal(err.code, TideJsErrorCodes.NET_NON_OK_STATUS);
+    assert.equal(err.httpStatus, 409);
+});
+
+test("_getSilent: 409 problem+json throws the structured pass-through error", async (t) => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async () => problemResponse(pascalCaseBody());
+    t.after(() => { globalThis.fetch = realFetch; });
+
+    const client = new ClientBase("http://ork.example");
+    const err = await expectThrow(() => client._getSilent("/x"));
+    assertStructuredReservedError(err);
+});
+
+// ---------------------------------------------------------------------------
+// 3. PromiseRace unanimous-code promotion (via WaitForNumberofORKs)
+// ---------------------------------------------------------------------------
+
+function reservedFailure(expirySeconds) {
+    return new TideError({
+        code: RESERVED_CODE,
+        displayMessage: "This username was recently reserved by another sign-up attempt",
+        messageKey: RESERVED_KEY,
+        messageParams: { minutes: "10", expirySeconds },
+        httpStatus: 409,
+        problemType: `urn:tide:errors:${RESERVED_CODE}`,
+        traceId: "00-aaaabbbbccccddddeeeeffff00001111-2222333344445555-01",
+        url: "http://ork.example/Network/Authentication/Users/GetReservers/uid123",
+        endpoint: "/Network/Authentication/Users/GetReservers/uid123",
+        method: "GET",
+    });
+}
+
+function transportFailure() {
+    return new TideError({
+        code: TideJsErrorCodes.NET_TIMEOUT,
+        displayMessage: "Network request timed out",
+        source: "Clients/ClientBase.ts:_get",
+    });
+}
+
+/** Drive WaitForNumberofORKs into the failure path with the given rejections. */
+function raceWith(failures, opts) {
+    const promises = failures.map(f => Promise.reject(f));
+    // customTimeout=50ms so the test does not wait the default 8s.
+    return WaitForNumberofORKs([], promises, "CMK", failures.length, null, null, 50, null, opts);
+}
+
+test("promotion: unanimous reserved code is promoted, representative = largest expirySeconds", async () => {
+    const failures = [reservedFailure("100"), reservedFailure("300"), reservedFailure("200")];
+    const err = await expectThrow(() => raceWith(failures, { promoteUnanimousCodes: true }));
+
+    assert.equal(err.name, "TideError", "promoted error must keep the TideError name invariant");
+    assert.equal(err.code, RESERVED_CODE);
+    assert.equal(err.messageKey, RESERVED_KEY);
+    assert.deepEqual(err.messageParams, { minutes: "10", expirySeconds: "300" },
+        "representative must be the failure with the largest numeric expirySeconds");
+    assert.equal(err.httpStatus, 409);
+    assert.equal(err.traceId, "00-aaaabbbbccccddddeeeeffff00001111-2222333344445555-01");
+    assert.match(err.source, /promoted: 3 identical per-ORK failures/);
+    assert.equal(err.details.length, 3, "aggregate details must be preserved");
+    assert.equal(err.cause, failures[1], "cause must be the representative failure");
+});
+
+test("promotion: absent/NaN expirySeconds falls back to first failure", async () => {
+    const noExpiry = new TideError({
+        code: RESERVED_CODE,
+        displayMessage: "reserved (no params)",
+        messageKey: RESERVED_KEY,
+    });
+    const alsoNoExpiry = new TideError({
+        code: RESERVED_CODE,
+        displayMessage: "reserved (NaN params)",
+        messageKey: RESERVED_KEY,
+        messageParams: { expirySeconds: "not-a-number" },
+    });
+    const err = await expectThrow(() => raceWith([noExpiry, alsoNoExpiry], { promoteUnanimousCodes: true }));
+    assert.equal(err.code, RESERVED_CODE);
+    assert.equal(err.cause, noExpiry);
+});
+
+test("promotion: mixed codes stay generic NET_THRESHOLD_FAILURE", async () => {
+    const failures = [reservedFailure("100"), transportFailure()];
+    const err = await expectThrow(() => raceWith(failures, { promoteUnanimousCodes: true }));
+    assert.equal(err.code, TideJsErrorCodes.NET_THRESHOLD_FAILURE);
+    assert.equal(err.details.length, 2);
+});
+
+test("promotion: unanimous TIDE-TIDEJS-* transport codes stay generic", async () => {
+    const failures = [transportFailure(), transportFailure(), transportFailure()];
+    const err = await expectThrow(() => raceWith(failures, { promoteUnanimousCodes: true }));
+    assert.equal(err.code, TideJsErrorCodes.NET_THRESHOLD_FAILURE);
+});
+
+test("promotion: flag off (default) keeps generic NET_THRESHOLD_FAILURE even when unanimous", async () => {
+    const failures = [reservedFailure("100"), reservedFailure("200")];
+    const err = await expectThrow(() => raceWith(failures));
+    assert.equal(err.code, TideJsErrorCodes.NET_THRESHOLD_FAILURE);
+    // The reserved code must still be reachable via details[].
+    assert.ok(err.details.every(d => d.code === RESERVED_CODE));
+});
+
+test("promotion: explicit false keeps generic NET_THRESHOLD_FAILURE", async () => {
+    const failures = [reservedFailure("100"), reservedFailure("200")];
+    const err = await expectThrow(() => raceWith(failures, { promoteUnanimousCodes: false }));
+    assert.equal(err.code, TideJsErrorCodes.NET_THRESHOLD_FAILURE);
+});

--- a/Tests/node-esm-extension-loader.mjs
+++ b/Tests/node-esm-extension-loader.mjs
@@ -1,0 +1,24 @@
+// Node ESM resolver hook for running the compiled `dist/` output under
+// `node --test`. tsc (moduleResolution: "bundler") emits extensionless
+// relative specifiers (e.g. `import ... from "../Errors/TideError"`), which
+// browsers-via-bundlers accept but plain Node ESM does not. This hook retries
+// failed relative resolutions with `.js` (then `/index.js`) appended.
+//
+// Registered by node-test-setup.mjs — see the `test` script in package.json.
+export async function resolve(specifier, context, nextResolve) {
+    try {
+        return await nextResolve(specifier, context);
+    } catch (err) {
+        if (
+            (specifier.startsWith("./") || specifier.startsWith("../"))
+            && !specifier.endsWith(".js") && !specifier.endsWith(".mjs")
+        ) {
+            try {
+                return await nextResolve(specifier + ".js", context);
+            } catch {
+                return await nextResolve(specifier + "/index.js", context);
+            }
+        }
+        throw err;
+    }
+}

--- a/Tests/node-test-setup.mjs
+++ b/Tests/node-test-setup.mjs
@@ -1,0 +1,5 @@
+// Registers the extension-appending ESM resolver before tests import dist/.
+// Used via: node --import ./Tests/node-test-setup.mjs --test <test files>
+import { register } from "node:module";
+
+register(new URL("./node-esm-extension-loader.mjs", import.meta.url));

--- a/Tools/TideMemory.ts
+++ b/Tools/TideMemory.ts
@@ -1,4 +1,7 @@
 // Tide Memory Object helper functions from tide-js
+import { TideError } from "../Errors/TideError";
+import { TideJsErrorCodes } from "../Errors/codes";
+
 export class TideMemory extends Uint8Array{
     static CreateFromArray(datas: Uint8Array[]): TideMemory   {
         if(datas.length == 0) return new TideMemory();
@@ -11,7 +14,7 @@ export class TideMemory extends Uint8Array{
     }
     static Create(initialValue: Uint8Array, totalLength: number, version: number = 1): TideMemory {
         if (totalLength < initialValue.length + 4) {
-            throw new Error("Not enough space to allocate requested data. Make sure to request more space in totalLength than length of InitialValue plus 4 bytes for length.");
+            throw new TideError({ code: TideJsErrorCodes.MEM_BUFFER_OVERFLOW, displayMessage: `Not enough space to allocate requested data. Make sure to request more space in totalLength than length of InitialValue plus 4 bytes for length. (totalLength=${totalLength}, initialValue.length=${initialValue.length}, required>=${initialValue.length + 4})`, source: "tide-js/Tools/TideMemory.ts:14" });
         }
 
         // Total buffer length is 4 (version) + totalLength
@@ -35,9 +38,9 @@ export class TideMemory extends Uint8Array{
     }
     
     WriteValue(index: number, value: Uint8Array): void {
-        if (index < 0) throw new Error("Index cannot be less than 0");
-        if (index === 0) throw new Error("Use CreateTideMemory to set value at index 0");
-        if (this.length < 4 + value.length) throw new Error("Could not write to memory. Memory too small for this value");
+        if (index < 0) throw new TideError({ code: TideJsErrorCodes.MEM_NEGATIVE_INDEX, displayMessage: "Index cannot be less than 0", source: "tide-js/Tools/TideMemory.ts:38" });
+        if (index === 0) throw new TideError({ code: TideJsErrorCodes.MEM_INDEX_ZERO_RESERVED, displayMessage: "Use CreateTideMemory to set value at index 0", source: "tide-js/Tools/TideMemory.ts:39" });
+        if (this.length < 4 + value.length) throw new TideError({ code: TideJsErrorCodes.MEM_BUFFER_OVERFLOW, displayMessage: `Could not write to memory. Memory too small for this value (this.length=${this.length}, required>=${4 + value.length})`, source: "tide-js/Tools/TideMemory.ts:40" });
 
         const dataView = new DataView(this.buffer);
         let dataLocationIndex = 4; // Start after the version number
@@ -45,7 +48,7 @@ export class TideMemory extends Uint8Array{
         // Navigate through existing data segments
         for (let i = 0; i < index; i++) {
             if (dataLocationIndex + 4 > this.length) {
-                throw new RangeError("Index out of range.");
+                throw new TideError({ code: TideJsErrorCodes.MEM_INDEX_OUT_OF_RANGE, displayMessage: `Index out of range. (while seeking to segment ${index}, sub-index ${i}, offset ${dataLocationIndex}+4 exceeds length ${this.length})`, source: "tide-js/Tools/TideMemory.ts:48" });
             }
 
             // Read data length at current position
@@ -57,13 +60,13 @@ export class TideMemory extends Uint8Array{
 
         // Check if there's enough space to write the value
         if (dataLocationIndex + 4 + value.length > this.length) {
-            throw new RangeError("Not enough space to write value");
+            throw new TideError({ code: TideJsErrorCodes.MEM_BUFFER_OVERFLOW, displayMessage: `Not enough space to write value (offset ${dataLocationIndex}+4+${value.length} exceeds length ${this.length})`, source: "tide-js/Tools/TideMemory.ts:60" });
         }
 
         // Check if data has already been written to this index
         const existingLength = dataView.getInt32(dataLocationIndex, true);
         if (existingLength !== 0) {
-            throw new Error("Data has already been written to this index");
+            throw new TideError({ code: TideJsErrorCodes.MEM_INDEX_ALREADY_WRITTEN, displayMessage: `Data has already been written to this index (index=${index}, offset=${dataLocationIndex}, existingLength=${existingLength})`, source: "tide-js/Tools/TideMemory.ts:66" });
         }
 
         // Write data length of value at current position
@@ -77,7 +80,7 @@ export class TideMemory extends Uint8Array{
     GetValue(index: number): TideMemory{
         // 'a' should be an ArrayBuffer or Uint8Array
         if (this.length < 4) {
-            throw new Error("Insufficient data to read.");
+            throw new TideError({ code: TideJsErrorCodes.MEM_INSUFFICIENT_DATA, displayMessage: `Insufficient data to read. (buffer length is ${this.length}, need at least 4 bytes for header)`, source: "tide-js/Tools/TideMemory.ts:80" });
         }
 
         // Create a DataView for reading integers in little-endian format
@@ -91,7 +94,7 @@ export class TideMemory extends Uint8Array{
         for (let i = 0; i < index; i++) {
             // Check if there's enough data to read the length of the next segment
             if (dataLocationIndex + 4 > this.length) {
-                throw new RangeError("Index out of range.");
+                throw new TideError({ code: TideJsErrorCodes.MEM_INDEX_OUT_OF_RANGE, displayMessage: `Index out of range. (requested segment ${index}, ran out at sub-index ${i}, offset ${dataLocationIndex}+4 exceeds length ${this.length})`, source: "tide-js/Tools/TideMemory.ts:94" });
             }
 
             const nextDataLength = dataView.getInt32(dataLocationIndex, true);
@@ -100,7 +103,7 @@ export class TideMemory extends Uint8Array{
 
         // Check if there's enough data to read the length of the final segment
         if (dataLocationIndex + 4 > this.length) {
-            throw new RangeError("Index out of range.");
+            throw new TideError({ code: TideJsErrorCodes.MEM_INDEX_OUT_OF_RANGE, displayMessage: `Index out of range. (requested segment ${index}, offset ${dataLocationIndex}+4 (length header) exceeds length ${this.length})`, source: "tide-js/Tools/TideMemory.ts:103" });
         }
 
         const finalDataLength = dataView.getInt32(dataLocationIndex, true);
@@ -108,7 +111,7 @@ export class TideMemory extends Uint8Array{
 
         // Check if the final data segment is within bounds
         if (dataLocationIndex + finalDataLength > this.length) {
-            throw new RangeError("Index out of range.");
+            throw new TideError({ code: TideJsErrorCodes.MEM_INDEX_OUT_OF_RANGE, displayMessage: `Index out of range. (requested segment ${index}, payload offset ${dataLocationIndex}+${finalDataLength} exceeds length ${this.length})`, source: "tide-js/Tools/TideMemory.ts:111" });
         }
 
         return this.subarray(dataLocationIndex, dataLocationIndex + finalDataLength) as TideMemory;

--- a/Tools/Utils.ts
+++ b/Tools/Utils.ts
@@ -56,17 +56,50 @@ export function CurrentTime(){
  */
 export interface WaitForORKsOptions {
     /**
-     * Opt-in: when the threshold is NOT met and EVERY per-ORK failure is a
-     * {@link TideError} carrying one identical upstream `code` (and that code
-     * is not a tide-js transport code, i.e. does not start with `TIDE-TIDEJS-`),
-     * throw a "promoted" TideError carrying that code / messageKey /
-     * messageParams instead of the generic `NET_THRESHOLD_FAILURE` aggregate.
+     * Opt-in: when the threshold is NOT met and the failure set covers the
+     * ENTIRE attempted cohort (every attempted ORK rejected — no successes,
+     * no still-pending promises cut off by the timeout) and EVERY per-ORK
+     * failure is a {@link TideError} carrying one identical upstream `code`
+     * (and that code is not a tide-js transport code, i.e. does not start
+     * with `TIDE-TIDEJS-`), throw a "promoted" TideError carrying that code /
+     * messageKey / messageParams instead of the generic
+     * `NET_THRESHOLD_FAILURE` aggregate.
+     *
+     * The full-cohort requirement is a security gate: without it, one fast
+     * malicious ORK plus slow/unreachable honest ORKs could fake "unanimity"
+     * at the timeout and misrepresent an outage as a cohort-attested error.
      *
      * Used by the reservation flow so a unanimous 409
      * `TIDE-ORK-KEYGEN-USERNAME_RESERVED` survives to the UI. Default: off —
      * all other callers keep byte-identical behaviour.
      */
     promoteUnanimousCodes?: boolean;
+}
+
+/**
+ * Representative-selection helper for unanimous-code promotion: among the
+ * failures whose `messageParams[param]` coerces to a FINITE number, return
+ * the failure holding the median value (even count -> lower median), or
+ * `null` if no failure qualifies.
+ *
+ * Median (not max/min) is the honest-majority rule: with one attacker in an
+ * otherwise-honest cohort the median is always a value an honest ORK sent,
+ * so a single member cannot drag the displayed value to an extreme.
+ * Non-finite coercions (NaN, +/-Infinity — e.g. `"9e999"`) are never
+ * candidates, so a poisoned value can never win.
+ */
+function _medianFailureByParam(failures: TideError[], param: string): TideError | null {
+    const candidates: { f: TideError; v: number }[] = [];
+    for (const f of failures) {
+        const raw = (f.messageParams as Record<string, unknown> | null | undefined)?.[param];
+        if (raw === undefined || raw === null) continue;
+        const v = Number(raw);
+        if (!Number.isFinite(v)) continue;
+        candidates.push({ f, v });
+    }
+    if (candidates.length === 0) return null;
+    candidates.sort((a, b) => a.v - b.v);
+    return candidates[Math.floor((candidates.length - 1) / 2)].f;
 }
 
 async function PromiseRace(promises: Promise<any>[], keyType: string, amountRequired: number, customTimeout: number = null, customPromiseChecker: Function = null, promoteUnanimousCodes: boolean = false) {
@@ -166,32 +199,53 @@ async function PromiseRace(promises: Promise<any>[], keyType: string, amountRequ
         // AFTER the "Too many attempts" special case above (admin-ui
         // string-matches that path) and BEFORE the generic
         // NET_THRESHOLD_FAILURE throw below.
+        // TRUE-unanimity gate: promotion requires the failure set to cover
+        // the FULL attempted cohort. `failed.length === initLength` means
+        // every attempted promise rejected — none succeeded (results would
+        // hold it), none were still pending when the timeout truncated the
+        // loop, and none resolved-but-failed a customPromiseChecker (those
+        // land in results, not failed). `results.length === 0` is asserted
+        // explicitly as belt-and-braces: any success whatsoever disqualifies
+        // promotion. A partial set falls through to NET_THRESHOLD_FAILURE.
         if (
             promoteUnanimousCodes
             && failed.length > 0
+            && failed.length === initLength
+            && results.length === 0
             && failed.every(f => TideError.isTideError(f))
         ) {
             const tideFailed = failed as TideError[];
             const unanimousCode = tideFailed[0].code;
             const unanimous = tideFailed.every(f => f.code === unanimousCode);
             if (unanimous && !unanimousCode.startsWith("TIDE-TIDEJS-")) {
-                // Representative = the failure with the LARGEST numeric
-                // `messageParams.expirySeconds` (values are STRINGS on the
-                // wire). NaN/absent values never win; if none are numeric,
-                // fall back to the first failure.
-                let representative = tideFailed[0];
-                let repExpiry = Number.NaN;
-                for (const f of tideFailed) {
-                    const expiry = Number(f.messageParams?.expirySeconds);
-                    if (!Number.isNaN(expiry) && (Number.isNaN(repExpiry) || expiry > repExpiry)) {
-                        representative = f;
-                        repExpiry = expiry;
-                    }
-                }
+                // Representative = median of numeric `messageParams.minutes`
+                // (values are STRINGS on the wire); fall back to median of
+                // `expirySeconds` for older ORKs that still send it; else the
+                // first failure. See _medianFailureByParam for the
+                // honest-majority rationale.
+                const representative =
+                    _medianFailureByParam(tideFailed, "minutes")
+                    ?? _medianFailureByParam(tideFailed, "expirySeconds")
+                    ?? tideFailed[0];
+
+                // Namespace guard: a PROMOTED messageKey may only select
+                // entries from the Tide error catalog. The Enclave's
+                // getTranslation resolves arbitrary dotted paths in its i18n
+                // bundle, so an unguarded key would let a unanimous cohort
+                // pick arbitrary catalog strings (social-engineering text).
+                // Outside the namespace we omit the key; the Enclave then
+                // falls back to displayMessage / code.
+                const repKey = representative.messageKey;
+                const promotedMessageKey =
+                    typeof repKey === "string"
+                        && (repKey.startsWith("error.tide.") || repKey.startsWith("errors.tide."))
+                        ? repKey
+                        : null;
+
                 throw new TideError({
                     code: representative.code,
                     displayMessage: representative.displayMessage,
-                    messageKey: representative.messageKey,    // verbatim — no prefix assumptions
+                    messageKey: promotedMessageKey,
                     messageParams: representative.messageParams,
                     httpStatus: representative.httpStatus,
                     problemType: representative.problemType,

--- a/Tools/Utils.ts
+++ b/Tools/Utils.ts
@@ -19,8 +19,8 @@ import OrkInfo from "../Models/Infos/OrkInfo";
 import { TideError, TideErrorDetail } from "../Errors/TideError";
 import { TideJsErrorCodes } from "../Errors/codes";
 
-export const Threshold = 14;
-export const Max = 20;
+export const Threshold = 3;
+export const Max = 5;
 
 /**
  * Reduce an arbitrary thrown value to a {@link TideErrorDetail} entry so the

--- a/Tools/Utils.ts
+++ b/Tools/Utils.ts
@@ -259,7 +259,7 @@ export function removeRandomElements(array: any[], targetArraySize: number): any
     let newArray = array.slice();
     // Check if the array size is > n
     if (newArray.length < targetArraySize) {
-        throw new Error("Array size must be greater than n.");
+        throw new TideError({ code: TideJsErrorCodes.SERIAL_INVALID_LENGTH, displayMessage: `Array size must be greater than n (got length=${newArray.length}, target=${targetArraySize}).`, source: "tide-js/Tools/Utils.ts:262" });
     }
     else if(newArray.length == targetArraySize) return newArray;
 

--- a/Tools/Utils.ts
+++ b/Tools/Utils.ts
@@ -50,7 +50,26 @@ export function CurrentTime(){
     return timeSkew ? now + Number(timeSkew) : now;
 }
 
-async function PromiseRace(promises: Promise<any>[], keyType: string, amountRequired: number, customTimeout: number = null, customPromiseChecker: Function = null) {
+/**
+ * Options bag for {@link WaitForNumberofORKs} / {@link PromiseRace}.
+ * Added as a bag (not a positional) because the positional list is already 8 long.
+ */
+export interface WaitForORKsOptions {
+    /**
+     * Opt-in: when the threshold is NOT met and EVERY per-ORK failure is a
+     * {@link TideError} carrying one identical upstream `code` (and that code
+     * is not a tide-js transport code, i.e. does not start with `TIDE-TIDEJS-`),
+     * throw a "promoted" TideError carrying that code / messageKey /
+     * messageParams instead of the generic `NET_THRESHOLD_FAILURE` aggregate.
+     *
+     * Used by the reservation flow so a unanimous 409
+     * `TIDE-ORK-KEYGEN-USERNAME_RESERVED` survives to the UI. Default: off —
+     * all other callers keep byte-identical behaviour.
+     */
+    promoteUnanimousCodes?: boolean;
+}
+
+async function PromiseRace(promises: Promise<any>[], keyType: string, amountRequired: number, customTimeout: number = null, customPromiseChecker: Function = null, promoteUnanimousCodes: boolean = false) {
     let results = [];
     let failed = [];
     let timeoutReached = false;
@@ -143,6 +162,47 @@ async function PromiseRace(promises: Promise<any>[], keyType: string, amountRequ
         const required = amountRequired;
         const totalAttempted = initLength;
 
+        // Opt-in unanimous-code promotion (see WaitForORKsOptions). Must stay
+        // AFTER the "Too many attempts" special case above (admin-ui
+        // string-matches that path) and BEFORE the generic
+        // NET_THRESHOLD_FAILURE throw below.
+        if (
+            promoteUnanimousCodes
+            && failed.length > 0
+            && failed.every(f => TideError.isTideError(f))
+        ) {
+            const tideFailed = failed as TideError[];
+            const unanimousCode = tideFailed[0].code;
+            const unanimous = tideFailed.every(f => f.code === unanimousCode);
+            if (unanimous && !unanimousCode.startsWith("TIDE-TIDEJS-")) {
+                // Representative = the failure with the LARGEST numeric
+                // `messageParams.expirySeconds` (values are STRINGS on the
+                // wire). NaN/absent values never win; if none are numeric,
+                // fall back to the first failure.
+                let representative = tideFailed[0];
+                let repExpiry = Number.NaN;
+                for (const f of tideFailed) {
+                    const expiry = Number(f.messageParams?.expirySeconds);
+                    if (!Number.isNaN(expiry) && (Number.isNaN(repExpiry) || expiry > repExpiry)) {
+                        representative = f;
+                        repExpiry = expiry;
+                    }
+                }
+                throw new TideError({
+                    code: representative.code,
+                    displayMessage: representative.displayMessage,
+                    messageKey: representative.messageKey,    // verbatim — no prefix assumptions
+                    messageParams: representative.messageParams,
+                    httpStatus: representative.httpStatus,
+                    problemType: representative.problemType,
+                    traceId: representative.traceId,
+                    source: `Tools/Utils.ts:PromiseRace (promoted: ${tideFailed.length} identical per-ORK failures)`,
+                    details,
+                    cause: representative,
+                });
+            }
+        }
+
         if (failed.length > 0) {
             throw new TideError({
                 code: TideJsErrorCodes.NET_THRESHOLD_FAILURE,
@@ -170,11 +230,11 @@ async function PromiseRace(promises: Promise<any>[], keyType: string, amountRequ
 }
 
 
-export async function WaitForNumberofORKs(orkList_Ref: OrkInfo[], pre_responses: Promise<any>[], keyType: string, amountRequired: number = Threshold, bitwise_p: (0 | 1)[] = null, optionalArray: any[] = null, customTimeout: number = null, customPromiseChecker: Function = null){
+export async function WaitForNumberofORKs(orkList_Ref: OrkInfo[], pre_responses: Promise<any>[], keyType: string, amountRequired: number = Threshold, bitwise_p: (0 | 1)[] = null, optionalArray: any[] = null, customTimeout: number = null, customPromiseChecker: Function = null, opts?: WaitForORKsOptions){
     // See Utils.cs on Midgard Core for how this can be improved
     // Basically, you don't need indexes in the responses, just use .indexOf
 
-    const unsortedResponses = await PromiseRace(pre_responses, keyType, amountRequired, customTimeout, customPromiseChecker);
+    const unsortedResponses = await PromiseRace(pre_responses, keyType, amountRequired, customTimeout, customPromiseChecker, opts?.promoteUnanimousCodes === true);
 	const sortedResponses = unsortedResponses.sort((a, b) => a.index - b.index);
 
     let bitwise = [];

--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,13 @@ export * as Tools from './Tools';
 import * as Utils from './Tools';
 export { Utils };
 
+// Top-level convenience re-exports for downstream consumers (e.g. ORK SWE)
+export { TideError } from "./Errors/TideError";
+export { TideJsErrorCodes } from "./Errors/codes";
+export type { TideErrorInit, TideErrorDetail } from "./Errors/TideError";
+export { RecentRequestsBuffer } from "./Clients/RecentRequestsBuffer";
+export type { RecentRequestEntry } from "./Clients/RecentRequestsBuffer";
+
 /**
  * Build-stamp for the tide-js bundle. The literal below is a placeholder; the
  * Main Agent rewrites it at commit time to the current git short-SHA so that

--- a/index.ts
+++ b/index.ts
@@ -27,3 +27,11 @@ export * as Tools from './Tools';
 // Backwards compatibility alias
 import * as Utils from './Tools';
 export { Utils };
+
+/**
+ * Build-stamp for the tide-js bundle. The literal below is a placeholder; the
+ * Main Agent rewrites it at commit time to the current git short-SHA so that
+ * any error report consumer (e.g. keycloak-IGA) can correlate a thrown
+ * TideError back to the exact source build.
+ */
+export const tideJsVersion = "0.0.1-pre-error-reporting";

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "rm -rf dist && tsc && node --import ./Tests/node-test-setup.mjs --test Tests/ReservationErrors.test.mjs"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tideorg/js",
-  "version": "0.13.32",
+  "version": "0.14.0",
   "description": "Browser side modules required to interact with the Tide's Cybersecurity Fabric.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Summary

<!-- 
High-level overview of what is included in this release.
Mention major features, fixes, and any notable changes.
-->

### Features:
- 
  
### Bug fixes:
- 
  
---

# Release Notes
* Expanded `TideError` coverage across Cryptide schemes, cryptographic primitives, models, tools, and utilities.
* Added `RecentRequestsBuffer` and `tideJsVersion` metadata to improve error diagnostics.
* Improved Problem Details handling with case-tolerant parsing and consistent `application/problem+json` pass-through.
* Added secure unanimous error-code promotion for concurrent `PromiseRace` failures.
* Added human-readable approval models for `ServerCert:1`, `vrkEnc:1`, `vrkDec:1`, and `AttestationUnit:1`.
* Improved approval-enclave cards with plain-language titles, role and user names, and action-neutral summaries.
* Rendered approval actions from signed canonical request bytes to prevent misleading grant descriptions.
* Fixed `PolicySignRequestBuilder` handling of empty draft placeholders.
* Added unit tests for reservation error propagation.
* Updated the `tide-js` package for the `0.14.0` release.

---

# Testing

<!-- 
Explain what has been tested and how. 
Link to test runs, screenshots, or logs where relevant.
-->

### Test Types

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end / UI tests
- [ ] Manual QA
- [ ] Performance / load tests
- [ ] Other (describe):
