### PR TITLE
Rename custom-model detection prefix from Custom< to BasicCustom<

### DIFF
--- a/Models/ModelRegistry.ts
+++ b/Models/ModelRegistry.ts
@@ -42,8 +42,8 @@ export interface HumanReadableContext {
 export class ModelRegistry {
     static getHumanReadableModelBuilder(reqId: string, data: Uint8Array, context?: HumanReadableContext): HumanReadableModelBuilder {
         const r = BaseTideRequest.decode(data);
-        const nameMatch = r.name.match(/^Custom<(.*)>$/)?.[1];
-        const versionMatch = r.version.match(/^Custom<(.*)>$/)?.[1];
+        const nameMatch = r.name.match(/^BasicCustom<(.*)>$/)?.[1];
+        const versionMatch = r.version.match(/^BasicCustom<(.*)>$/)?.[1];
         if (nameMatch && versionMatch) {
             return new CustomSignRequestBuilder(data, reqId, context);
         }
@@ -100,8 +100,8 @@ class CustomSignRequestBuilder extends HumanReadableModelBuilder {
     get _id() { return this._name + ":" + this._version; }
     constructor(data, reqId, context?: HumanReadableContext) {
         super(data, reqId, context);
-        this._name = this.request.name.match(/^Custom<(.*)>$/)?.[1];
-        this._version = this.request.version.match(/^Custom<(.*)>$/)?.[1];
+        this._name = this.request.name.match(/^BasicCustom<(.*)>$/)?.[1];
+        this._version = this.request.version.match(/^BasicCustom<(.*)>$/)?.[1];
         this.humanReadableJson = JSON.parse(StringFromUint8Array(GetValue(this.request.draft, 0)));
         this._humanReadableName = this.humanReadableJson["humanReadableName"];
     }


### PR DESCRIPTION
## What changed

The custom-model detection prefix in `Models/ModelRegistry.ts` moves from `Custom<` to `BasicCustom<`, at 4 sites:

| Location | Sites |
|---|---|
| `ModelRegistry.getHumanReadableModelBuilder` | `r.name` and `r.version` match |
| `CustomSignRequestBuilder` constructor | `this.request.name` and `this.request.version` match |

Each regex changes from `/^Custom<(.*)>$/` to `/^BasicCustom<(.*)>$/`. No other change is included: one file, +4/-4.

## Compatibility note

This is a breaking change for producers, and no fallback branch for the old prefix is included.

The published `dist/` for 0.14.2 matches the bare `Custom<` prefix, and every remote branch checked still emits/expects that bare prefix, including the current `release/0.14.22`, `staging`, and `main`. All four detection sites are unchanged on those branches.

Consequence once this ships: any producer still emitting `Custom<X>` will no longer match, so `getHumanReadableModelBuilder` will fall through to `MODEL_UNKNOWN_MODEL` and that model will lose its approval card. Producers must be moved to `BasicCustom<X>` in step with this change, or a fallback branch accepting both prefixes should be added before release.

## Base

Branched from `main` rather than from `release/0.14.2`, so this PR contains exactly one commit and one file. `Models/ModelRegistry.ts` is identical on `main` and `release/0.14.2`, so the change applies cleanly either way.
